### PR TITLE
Creates classes and infrastructure for station complements in plugins

### DIFF
--- a/server/src/classes/Card.ts
+++ b/server/src/classes/Card.ts
@@ -1,18 +1,15 @@
 import uniqid from "@thorium/uniqid";
 type CardConfig = unknown;
 export class Card {
-  id: string;
-
   name: string;
 
   component: string;
 
-  config: CardConfig;
+  config?: CardConfig;
 
-  icon: string | null;
+  icon?: string | null;
 
   constructor(params: Partial<Card>) {
-    this.id = params.id || uniqid("crd-");
     this.name = params.name || "Card";
     this.component = params.component || "Card";
     this.config = params.config;

--- a/server/src/classes/Plugins/StationComplement.test.ts
+++ b/server/src/classes/Plugins/StationComplement.test.ts
@@ -25,9 +25,6 @@ describe("StationComplementPlugin", () => {
     expect(stationComplement).toBeInstanceOf(StationComplementPlugin);
     expect(stationComplement.name).toBe("New Station Complement");
     expect(stationComplement.stationCount).toBe(0);
-    await fs.rm(path.resolve(path.join(".", plugin.path, "..")), {
-      recursive: true,
-    });
   });
   it("should load test yaml", async () => {
     const plugin = new Plugin({name: "Test Plugin"}, {

--- a/server/src/classes/Plugins/StationComplement.test.ts
+++ b/server/src/classes/Plugins/StationComplement.test.ts
@@ -1,0 +1,62 @@
+import StationComplementPlugin from "./StationComplement";
+import Plugin from "./index";
+import {ServerDataModel} from "../ServerDataModel";
+import {promises as fs} from "fs";
+import path from "path";
+const testYaml = `apiVersion: "stations/v1"
+kind: "stations"
+name: "Test Station"
+hasShipMap: false
+stations:
+  - name: Pilot
+    description: A single player position that controls all aspects of the ship.
+    logo: Pilot.svg
+    cards:
+      - name: Pilot
+        component: Pilot
+`;
+describe("StationComplementPlugin", () => {
+  afterAll(async () => {
+    await fs.rm("./plugins", {recursive: true});
+  });
+  it("should instantiate correctly", async () => {
+    const plugin = new Plugin({}, {plugins: []} as unknown as ServerDataModel);
+    const stationComplement = new StationComplementPlugin({}, plugin);
+    expect(stationComplement).toBeInstanceOf(StationComplementPlugin);
+    expect(stationComplement.name).toBe("New Station Complement");
+    expect(stationComplement.stationCount).toBe(0);
+    await fs.rm(path.resolve(path.join(".", plugin.path, "..")), {
+      recursive: true,
+    });
+  });
+  it("should load test yaml", async () => {
+    const plugin = new Plugin({name: "Test Plugin"}, {
+      plugins: [],
+    } as unknown as ServerDataModel);
+    await plugin.writeFile(true);
+    await fs.mkdir(
+      path.resolve(
+        path.join(".", plugin.path, "../stationComplements/Test Station")
+      ),
+      {recursive: true}
+    );
+    await fs.writeFile(
+      path.resolve(
+        path.join(
+          ".",
+          plugin.path,
+          "../stationComplements/Test Station/manifest.yml"
+        )
+      ),
+      testYaml
+    );
+    const stationComplement = new StationComplementPlugin(
+      {name: "Test Station"},
+      plugin
+    );
+    expect(stationComplement.name).toBe("Test Station");
+    expect(stationComplement.stationCount).toBe(1);
+    expect(stationComplement.stations[0].name).toBe("Pilot");
+    expect(stationComplement.assets["Pilot-logo"]).toBeTruthy();
+  });
+});

--- a/server/src/classes/Plugins/StationComplement.ts
+++ b/server/src/classes/Plugins/StationComplement.ts
@@ -1,0 +1,43 @@
+import {generateIncrementedName} from "server/src/utils/generateIncrementedName";
+import BasePlugin from ".";
+import Station from "../Station";
+import {Aspect} from "./Aspect";
+
+export default class StationComplementPlugin extends Aspect {
+  apiVersion = "stations/v1" as const;
+  kind = "stationComplements" as const;
+  name: string;
+  hasShipMap: boolean;
+  stations: Station[] = [];
+  get stationCount() {
+    return this.stations.length;
+  }
+  assets = {};
+  constructor(params: Partial<StationComplementPlugin>, plugin: BasePlugin) {
+    const name = generateIncrementedName(
+      params.name || "New Station Complement",
+      plugin.aspects.stationComplements.map(station => station.name)
+    );
+    super({name, ...params}, {kind: "stationComplements"}, plugin);
+
+    this.name = name;
+    this.hasShipMap = params.hasShipMap || false;
+    this.stations = params.stations || [];
+    this.assets = this.stations.reduce((assets, station) => {
+      const cardIcons = station.cards.reduce(
+        (icons: Record<string, string>, card) => {
+          if (card.icon) {
+            icons[`${station.name}-${card.name}-icon`] = card.icon;
+          }
+          return icons;
+        },
+        {}
+      );
+      return {
+        ...assets,
+        [`${station.name}-logo`]: station.logo,
+        ...cardIcons,
+      };
+    }, {});
+  }
+}

--- a/server/src/classes/Plugins/StationComplement.ts
+++ b/server/src/classes/Plugins/StationComplement.ts
@@ -6,13 +6,13 @@ import {Aspect} from "./Aspect";
 export default class StationComplementPlugin extends Aspect {
   apiVersion = "stations/v1" as const;
   kind = "stationComplements" as const;
-  name: string;
-  hasShipMap: boolean;
-  stations: Station[] = [];
+  name!: string;
+  hasShipMap!: boolean;
+  stations!: Station[];
   get stationCount() {
     return this.stations.length;
   }
-  assets = {};
+  assets!: Record<string, string>;
   constructor(params: Partial<StationComplementPlugin>, plugin: BasePlugin) {
     const name = generateIncrementedName(
       params.name || "New Station Complement",
@@ -20,9 +20,10 @@ export default class StationComplementPlugin extends Aspect {
     );
     super({name, ...params}, {kind: "stationComplements"}, plugin);
 
-    this.name = name;
-    this.hasShipMap = params.hasShipMap || false;
-    this.stations = params.stations || [];
+    this.stations = this.stations || params.stations || [];
+    this.hasShipMap = this.hasShipMap || params.hasShipMap || false;
+    this.assets = this.assets || params.assets || {};
+
     this.assets = this.stations.reduce((assets, station) => {
       const cardIcons = station.cards.reduce(
         (icons: Record<string, string>, card) => {
@@ -33,6 +34,7 @@ export default class StationComplementPlugin extends Aspect {
         },
         {}
       );
+
       return {
         ...assets,
         [`${station.name}-logo`]: station.logo,

--- a/server/src/classes/Plugins/index.ts
+++ b/server/src/classes/Plugins/index.ts
@@ -8,6 +8,8 @@ import fs from "fs/promises";
 import {YAMLSemanticError} from "yaml/util";
 import {FSDataStore} from "@thorium/db-fs";
 import path from "path";
+import StationComplementPlugin from "./StationComplement";
+import {loadFolderYaml} from "server/src/utils/loadFolderYaml";
 
 export function pluginPublish(plugin: BasePlugin) {
   pubsub.publish("pluginsList", {
@@ -20,6 +22,7 @@ export function pluginPublish(plugin: BasePlugin) {
 
 interface Aspects {
   ships: ShipPlugin[];
+  stationComplements: StationComplementPlugin[];
 }
 // Storing the server here so it doesn't get
 // serialized with the plugin.
@@ -76,6 +79,7 @@ export default class BasePlugin extends FSDataStore {
     if (!aspects) {
       aspects = {
         ships: [],
+        stationComplements: [],
       };
       pluginAspects.set(this, aspects);
     }
@@ -83,6 +87,12 @@ export default class BasePlugin extends FSDataStore {
   }
   async loadAspects() {
     this.aspects.ships = await BasePlugin.loadAspect(this, "ships", ShipPlugin);
+
+    this.aspects.stationComplements = await BasePlugin.loadAspect(
+      this,
+      "stationComplements",
+      StationComplementPlugin
+    );
   }
   toJSON() {
     const {_coverImage, ...data} = this;

--- a/server/src/classes/Station.ts
+++ b/server/src/classes/Station.ts
@@ -2,7 +2,8 @@ import uuid from "@thorium/uniqid";
 import {Card} from "./Card";
 
 export default class Station {
-  id: string;
+  apiVersion = "stations/v1" as const;
+  kind = "stations" as const;
 
   name: string;
 
@@ -10,19 +11,18 @@ export default class Station {
 
   logo: string;
 
-  layout: string;
+  theme: string;
 
   tags: string[];
 
   cards: Card[];
 
   constructor(params: Partial<Station>) {
-    this.id = params.id || uuid("sta-");
     this.name = params.name || "Station";
     this.description = params.description || "";
     this.tags = params.tags || [];
     this.logo = params.logo || "";
-    this.layout = params.layout || "Default";
+    this.theme = params.theme || "Default";
     this.cards = [];
     params.cards?.forEach(c => this.cards.push(new Card(c)));
   }

--- a/server/src/components/stationComplement.ts
+++ b/server/src/components/stationComplement.ts
@@ -9,6 +9,8 @@ export class StationComplementComponent extends Component {
 
   name: string = "Station Complement";
 
+  hasShipMap: boolean = false;
+
   stations: Station[] = [];
 
   init(params: Partial<StationComplementComponent>) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This is necessary so assets can be included with stations,
including station logos and card icons. It opens the possibility
of folks creating custom station sets in the future, but we won't
build any APIs or UIs for that right now.


## Related Issue

<!--- Most pull requests should have linked issues, though small changes do not -->
<!--- This is to make sure every change has the opportunity to be discussed before being added to the project. -->
<!--- If suggesting a large new feature or change, please discuss it in an issue first -->
<!--- Small changes can be discussed in this pull request, so a related issue is not required -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- You can reference an issue by saying "Refs #123" or close an issue when this pull request is merged by saying "Closes #123"
<!--- Please link to the issue here: -->

Closes #87

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manual testing, no automated tests yet.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs Change (changes were only made to documentation)
- [ ] Refactor (non-breaking change which improves code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, make sure you've read the CONTRIBUTING document. -->
<!--- If you still have questions, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the built-in project documentation.
- [ ] My change adds dependencies to this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
