### PR TITLE
enable plugins for windows

### DIFF
--- a/server/src/utils/appPaths.ts
+++ b/server/src/utils/appPaths.ts
@@ -24,6 +24,9 @@ if (process.env.THORIUM_PATH) {
   }
 }
 
+/* format path to function with windows machines */
+thoriumPath = thoriumPath.replaceAll('\\', '/');
+
 fs.mkdirSync(thoriumPath, {recursive: true});
 
 export const databaseName =


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Plugins were previously not accessible for Windows machines due to an issue with thorianPath string formatting.
These changes fix the thoriumPath to be windows compatible.

<!--- Describe your changes in detail.  Why is this change required? What problem does it solve? -->

Replace backslashes in thoriumPath with forward slashes

## How do you know the changes work correctly?
I use a windows machine and can now access plugins. **I have not confirmed that these changes are mac/linux compatible, and I ask that a reviewer confirm this functionality during the code review**

This is confirmed by initiating the "start flight" flow. A user on a windows machine should be able load and view available ships.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs Change (changes were only made to documentation)
- [ ] Refactor (non-breaking change which improves code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      change)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the built-in project documentation.
- [ ] My change adds dependencies to this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
