### PR TITLE
fix: Hide the menubar when kiosked on Windows. Closes #441

### DIFF
--- a/desktop/main/electron.ts
+++ b/desktop/main/electron.ts
@@ -62,6 +62,7 @@ async function createWindow() {
     minHeight: 768,
     minWidth: 1024,
     backgroundColor: "#251029",
+    autoHideMenuBar: true,
     webPreferences: {
       nodeIntegration: true,
       devTools: true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of Changes

**UI:**

- Activate Electron's `autoHideMenubar` option when creating the Kiosk window.

## Related Issue

<!--- Most pull requests should have linked issues, though small changes do not -->
<!--- This is to make sure every change has the opportunity to be discussed before being added to the project. -->
<!--- If suggesting a large new feature or change, please discuss it in an issue first -->
<!--- Small changes can be discussed in this pull request, so a related issue is not required -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- You can reference an issue by saying "Refs #123" or close an issue when this pull request is merged by saying "Closes #123"
<!--- Please link to the issue here: -->
Closes #441

## How do you know the changes work correctly?

<!-- Either describe the automated tests that you wrote -->
<!-- Or describe the steps that someone else can take to -->
<!-- check if your change does what it is supposed to -->
<!-- Eg. provide a test plan the reviewer can follow -->

Built the app for Windows and ran it on a Windows computer, putting it into Kiosk mode to see that the app menubar was hidden.

