### PR TITLE
fix: Editor palette no longer hides itself.

### DIFF
--- a/client/src/pages/Config/Starmap/index.tsx
+++ b/client/src/pages/Config/Starmap/index.tsx
@@ -97,12 +97,16 @@ export default function StarMap() {
         isOpen={selectedObjectIds.length > 0}
         onClose={() => useStarmapStore.setState({selectedObjectIds: []})}
       >
-        {systemId ? <SolarSystemPalette /> : <InterstellarPaletteWrapper />}
+        <React.Suspense fallback={null}>
+          {systemId ? <SolarSystemPalette /> : <InterstellarPaletteWrapper />}
+        </React.Suspense>
       </EditorPalette>
       <div className="h-[calc(100%-2rem)]  relative bg-black">
-        <StarmapCanvas>
-          <StarmapScene ref={sceneRef} />
-        </StarmapCanvas>
+        <React.Suspense fallback={null}>
+          <StarmapCanvas>
+            <StarmapScene ref={sceneRef} />
+          </StarmapCanvas>
+        </React.Suspense>
 
         <StatusBar />
       </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of Changes


**UI:**

- Add suspense boundaries around the editor palette content to make it so the palette doesn't disappear randomly.

## Related Issue

<!--- Most pull requests should have linked issues, though small changes do not -->
<!--- This is to make sure every change has the opportunity to be discussed before being added to the project. -->
<!--- If suggesting a large new feature or change, please discuss it in an issue first -->
<!--- Small changes can be discussed in this pull request, so a related issue is not required -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- You can reference an issue by saying "Refs #123" or close an issue when this pull request is merged by saying "Closes #123"
<!--- Please link to the issue here: -->

Closes #457 

## How do you know the changes work correctly?

<!-- Either describe the automated tests that you wrote -->
<!-- Or describe the steps that someone else can take to -->
<!-- check if your change does what it is supposed to -->
<!-- Eg. provide a test plan the reviewer can follow -->

Manual testing
- Go to the starmap editor
- Click one of the systems. The editor palette should appear.
- Double-click to enter the system. The editor palette should remain.

