### PR TITLE
fix: Hide autopilot lines on viewscreen

### DIFF
--- a/client/src/components/Starmap/StarmapShip.tsx
+++ b/client/src/components/Starmap/StarmapShip.tsx
@@ -47,6 +47,7 @@ export function StarmapShip({
   const isNotViewscreen = useStarmapStore(
     store => store.viewingMode !== "viewscreen"
   );
+  const isCore = useStarmapStore(store => store.viewingMode === "core");
 
   const group = useRef<Group>(null);
   const shipMesh = useRef<Group>(null);
@@ -79,6 +80,7 @@ export function StarmapShip({
     // Autopilot Destination
     if (lineRef.current && group.current) {
       if (
+        isCore &&
         // TODO September 14, 2022 - Make it so you can toggle autopilot lines on and off
         // useConfigStore.getState().includeAutopilotData &&
         shipAutopilot?.destinationPosition
@@ -99,7 +101,7 @@ export function StarmapShip({
         lineRef.current.geometry.attributes.position.needsUpdate = true;
         lineRef.current.visible = true;
       } else {
-        // lineRef.current.visible = false;
+        lineRef.current.visible = false;
       }
     }
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of Changes

**UI:**

- Only show the autopilot lines on Core. 

## Related Issue

<!--- Most pull requests should have linked issues, though small changes do not -->
<!--- This is to make sure every change has the opportunity to be discussed before being added to the project. -->
<!--- If suggesting a large new feature or change, please discuss it in an issue first -->
<!--- Small changes can be discussed in this pull request, so a related issue is not required -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- You can reference an issue by saying "Refs #123" or close an issue when this pull request is merged by saying "Closes #123"
<!--- Please link to the issue here: -->

Closes #490

## How do you know the changes work correctly?

<!-- Either describe the automated tests that you wrote -->
<!-- Or describe the steps that someone else can take to -->
<!-- check if your change does what it is supposed to -->
<!-- Eg. provide a test plan the reviewer can follow -->

Open two clients, one with pilot and one with view screen.
Place a waypoint with the navigation card.
Use Pilot to set course to that waypoint. Activate engines.
The autopilot line should not appear on the view screen.
Going to the Flight Director screen should show the autopilot line.

