### PR TITLE
fix: Adjust waypoint distance to not be so close to planets.

### DIFF
--- a/client/src/cards/Navigation/data.tsx
+++ b/client/src/cards/Navigation/data.tsx
@@ -269,6 +269,7 @@ export const waypoints = t.router({
       let systemId: number | null = null;
       let object: Entity | undefined = undefined;
       if ("entityId" in input) {
+        // This waypoint is being attached to a specific object in space.
         object = ctx.flight?.ecs.entities.find(e => e.id === input.entityId);
         if (!object) throw new Error("No object found.");
         position = getObjectOffsetPosition(object, ship);
@@ -293,6 +294,7 @@ export const waypoints = t.router({
           return maybeWaypoint;
         }
       } else if ("position" in input) {
+        // This waypoint is just being plopped at some random point in space.
         position = input.position;
         systemId = input.systemId;
       } else {
@@ -437,14 +439,14 @@ function getObjectOffsetPosition(object: Entity, ship: Entity) {
   } else {
     // Take the vector that we've calculated and set the waypoint position along that line
     // with a bit of distance. The distance is proportional to the radius of the object itself
-    // and the size of the ship: distanceFromCenter = crewShipSize * 2 + objectSize * 0.5
+    // and the size of the ship: distanceFromCenter = crewShipSize * 2 + objectSize * 2
     const objectSize =
       object.components.size?.length ||
       object.components.isPlanet?.radius ||
       solarRadiusToKilometers(object.components.isStar?.radius || 1) ||
       1;
     const distanceFromCenter =
-      ((ship.components.size?.length || 1) / 1000) * 2 + objectSize * 1.25;
+      ((ship.components.size?.length || 1) / 1000) * 2 + objectSize * 3;
 
     return objectAngle.multiplyScalar(distanceFromCenter).add(objectCenter);
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of Changes

- Make waypoints spawn 3x the radius of the target away from the target. This places planets in a nice sweet spot when you approach them, where the whole planet fills the view screen.

## Related Issue

<!--- Most pull requests should have linked issues, though small changes do not -->
<!--- This is to make sure every change has the opportunity to be discussed before being added to the project. -->
<!--- If suggesting a large new feature or change, please discuss it in an issue first -->
<!--- Small changes can be discussed in this pull request, so a related issue is not required -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- You can reference an issue by saying "Refs #123" or close an issue when this pull request is merged by saying "Closes #123"
<!--- Please link to the issue here: -->

Closes #492 

## How do you know the changes work correctly?

<!-- Either describe the automated tests that you wrote -->
<!-- Or describe the steps that someone else can take to -->
<!-- check if your change does what it is supposed to -->
<!-- Eg. provide a test plan the reviewer can follow -->

Start a flight
Use the navigation card to set course for Mars
Use the pilot card to point at the waypoint and activate autopilot (only using yaw and pitch thrusters - roll is whack)
Wait for the janky autopilot to finally get you there.
Look at the viewscreen and behold a lovely planet.

## Screenshots (if appropriate):

![Screenshot 2023-01-14 at 9 11 24 PM](https://user-images.githubusercontent.com/6558157/212518450-127dfa36-b98c-4ffc-aa7c-c43650b849b6.jpg)
