### PR TITLE
fix: Improves thrust autopilot behavior

### DIFF
--- a/server/src/systems/AutoThrustSystem.ts
+++ b/server/src/systems/AutoThrustSystem.ts
@@ -24,11 +24,11 @@ let matrix = new Matrix4();
 const rotationMatrix = new Matrix4().makeRotationY(-Math.PI);
 let desiredRotationQuat = new Quaternion();
 
-const IMPULSE_PROPORTION = 10;
-const IMPULSE_INTEGRAL = 0.1;
-const IMPULSE_DERIVATIVE = 25;
+const IMPULSE_PROPORTION = 1;
+const IMPULSE_DERIVATIVE = 0.5;
+const IMPULSE_INTEGRAL = 0.5;
 const WARP_PROPORTION = 1;
-const WARP_INTEGRAL = 0;
+const WARP_INTEGRAL = 0.5;
 const WARP_DERIVATIVE = 0.5;
 
 export class AutoThrustSystem extends System {
@@ -247,5 +247,5 @@ function getWarpFactorFromDesiredSpeed(
   const speedOutput =
     (desiredSpeed * (warpFactorCount - 1)) / (cruisingSpeed - minWarp) + 1;
 
-  return speedOutput;
+  return Math.max(1, speedOutput);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of Changes

- Tunes the PID controller of the warp and impulse to smooth out the speeds.
- Makes it so the warp engines cannot be set to a value less than warp 1, which limits warp jerkiness.

## Related Issue

<!--- Most pull requests should have linked issues, though small changes do not -->
<!--- This is to make sure every change has the opportunity to be discussed before being added to the project. -->
<!--- If suggesting a large new feature or change, please discuss it in an issue first -->
<!--- Small changes can be discussed in this pull request, so a related issue is not required -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- You can reference an issue by saying "Refs #123" or close an issue when this pull request is merged by saying "Closes #123"
<!--- Please link to the issue here: -->

Closes #494

## How do you know the changes work correctly?

<!-- Either describe the automated tests that you wrote -->
<!-- Or describe the steps that someone else can take to -->
<!-- check if your change does what it is supposed to -->
<!-- Eg. provide a test plan the reviewer can follow -->

Manual test: 
Set course for mars, activate autopilot, watch the speed be smooth
In order to run this test, the `inCorrectDirection` variable in `/server/src/systems/AutoThrustSystem.ts:145` should be hardcoded to `true` so the thruster autopilot doesn't affect the test.
