### PR TITLE
fix: Remove waypoints from the core starmap.

### DIFF
--- a/client/src/cores/StarmapCore/index.tsx
+++ b/client/src/cores/StarmapCore/index.tsx
@@ -316,6 +316,7 @@ export function SolarSystemWrapper() {
 
   const selectedObjectIds = useStarmapStore(store => store.selectedObjectIds);
   const planetsHidden = useStarmapStore(store => store.planetsHidden);
+  const isCore = useStarmapStore(store => store.viewingMode === "core");
 
   const {interpolate} = useLiveQuery();
   return (
@@ -369,9 +370,11 @@ export function SolarSystemWrapper() {
 
         return null;
       })}
-      {waypoints.map(waypoint => (
-        <WaypointEntity key={waypoint.id} waypoint={waypoint} viewscreen />
-      ))}
+      {isCore
+        ? null
+        : waypoints.map(waypoint => (
+            <WaypointEntity key={waypoint.id} waypoint={waypoint} viewscreen />
+          ))}
       {starmapShips.map(ship => (
         <Suspense key={ship.id} fallback={null}>
           <ErrorBoundary


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of Changes

- Removes waypoints from the starmap core entirely. We'll add them back in with a better UX later on.

The reason for this change has to do with multi-ship flights. Which ship's waypoints should be visible? That needs to be more carefully considered before just diving in.

## Related Issue

<!--- Most pull requests should have linked issues, though small changes do not -->
<!--- This is to make sure every change has the opportunity to be discussed before being added to the project. -->
<!--- If suggesting a large new feature or change, please discuss it in an issue first -->
<!--- Small changes can be discussed in this pull request, so a related issue is not required -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- You can reference an issue by saying "Refs #123" or close an issue when this pull request is merged by saying "Closes #123"
<!--- Please link to the issue here: -->

Closes #499

## How do you know the changes work correctly?

<!-- Either describe the automated tests that you wrote -->
<!-- Or describe the steps that someone else can take to -->
<!-- check if your change does what it is supposed to -->
<!-- Eg. provide a test plan the reviewer can follow -->

Manual testing:
Start a flight and go to the Pilot
Set a waypoint to a planet in a system, like Mars
Go to the Flight Director
Open the starmap core and go to any system.
The waypoint should not be there, including in the system where Mars is.
