### PR TITLE
fix: User experience improvements to starmaps

### DIFF
--- a/client/src/cards/Navigation/MapControls.tsx
+++ b/client/src/cards/Navigation/MapControls.tsx
@@ -6,10 +6,10 @@ import {useEffect, useRef} from "react";
 import {SOLAR_SYSTEM_MAX_DISTANCE} from "@client/components/Starmap/SolarSystemMap";
 import {INTERSTELLAR_MAX_DISTANCE} from "@client/components/Starmap/InterstellarMap";
 import {lightYearToLightMinute} from "@server/utils/unitTypes";
+
 export function MapControls() {
   const useStarmapStore = useGetStarmapStore();
   const systemId = useStarmapStore(state => state.currentSystem);
-  const rendered = useRef(false);
   const [ship] = q.navigation.ship.useNetRequest();
 
   useEffect(() => {
@@ -55,13 +55,7 @@ export function MapControls() {
               ? lightYearToLightMinute(INTERSTELLAR_MAX_DISTANCE)
               : SOLAR_SYSTEM_MAX_DISTANCE;
           if (ship.position) {
-            useStarmapStore
-              .getState()
-              .cameraControls?.current?.setPosition(
-                ship.position?.x,
-                y / 2,
-                ship.position?.z
-              );
+            useStarmapStore.getState().setCameraFocus(ship.position);
           }
         }}
       >
@@ -73,7 +67,7 @@ export function MapControls() {
 
 export const ZoomSliderComp = () => {
   const useStarmapStore = useGetStarmapStore();
-  const cameraZoom = useStarmapStore(store => store.cameraVerticalDistance);
+  const cameraZoom = useStarmapStore(store => store.cameraObjectDistance);
   const cameraControls = useStarmapStore(store => store.cameraControls);
   const maxDistance = cameraControls?.current?.maxDistance || 30000000000;
   const minDistance = cameraControls?.current?.minDistance || 10000;

--- a/client/src/cards/Navigation/SolarSystemWrapper.tsx
+++ b/client/src/cards/Navigation/SolarSystemWrapper.tsx
@@ -65,9 +65,16 @@ export function SolarSystemWrapper() {
                 onPointerOut={e => {
                   document.body.style.cursor = "auto";
                 }}
-                onClick={() =>
-                  useStarmapStore.setState({selectedObjectIds: [entity.id]})
-                }
+                onClick={() => {
+                  if (entity.components.satellite) {
+                    const position = getOrbitPosition(
+                      entity.components.satellite
+                    );
+                    useStarmapStore.getState().setCameraFocus(position);
+                  }
+
+                  useStarmapStore.setState({selectedObjectIds: [entity.id]});
+                }}
               >
                 <StarSprite size={size} color1={color} />
               </group>
@@ -93,9 +100,10 @@ export function SolarSystemWrapper() {
               satellites={satellites}
               inclination={inclination}
               radiusY={radiusY}
-              onClick={() =>
-                useStarmapStore.setState({selectedObjectIds: [entity.id]})
-              }
+              onClick={() => {
+                useStarmapStore.setState({selectedObjectIds: [entity.id]});
+                useStarmapStore.getState().setCameraFocus(position);
+              }}
             />
           );
         }

--- a/client/src/cards/Navigation/index.tsx
+++ b/client/src/cards/Navigation/index.tsx
@@ -100,7 +100,6 @@ function Waypoints() {
                         await q.waypoints.delete.netSend({waypointId: id});
                       } catch (err) {
                         if (err instanceof Error) {
-                          console.log(err);
                           toast({color: "error", title: err.message});
                         }
                       }

--- a/client/src/components/QuoteOfTheDay.tsx
+++ b/client/src/components/QuoteOfTheDay.tsx
@@ -242,6 +242,8 @@ const quotes = [
   "Hope is not the conviction that something will turn out well, but the certainty that something is worth doing no matter how it turns out.",
   // Pierre Coubertin
   "The important thing in life is not the triumph, but the struggle.",
+  // Sarah Williams
+  "Though my soul may set in darkness, it will rise in perfect light; I have loved the stars too fondly to be fearful of the night.",
 ];
 
 const QuoteOfTheDay = () => {

--- a/client/src/components/Starmap/OrbitContainer.tsx
+++ b/client/src/components/Starmap/OrbitContainer.tsx
@@ -18,7 +18,7 @@ export const OrbitLine: React.FC<{radiusX: number; radiusY: number}> = ({
     );
 
     const points = curve.getPoints(
-      Math.round(Math.max(1000, radiusX / 400000))
+      Math.round(Math.max(10000, radiusX / 400000))
     );
 
     const geometry = new BufferGeometry().setFromPoints(points);

--- a/client/src/components/Starmap/Planet/index.tsx
+++ b/client/src/components/Starmap/Planet/index.tsx
@@ -122,9 +122,7 @@ export function Planet({
       labelRef.current.quaternion.copy(camera.quaternion);
     }
 
-    const distance = camera.position.distanceTo(
-      distanceVector.set(camera.position.x, 0, camera.position.z)
-    );
+    const distance = camera.position.distanceTo(position);
 
     if (planetSpriteRef.current && planetMeshRef.current) {
       if (

--- a/client/src/components/Starmap/SolarSystemMap.tsx
+++ b/client/src/components/Starmap/SolarSystemMap.tsx
@@ -100,7 +100,6 @@ export function SolarSystemMap({
   const viewingMode = useStarmapStore(store => store.viewingMode);
 
   const isViewscreen = viewingMode === "viewscreen";
-  const isStation = viewingMode === "station";
 
   return (
     <Suspense fallback={null}>
@@ -119,7 +118,7 @@ export function SolarSystemMap({
               middle: ACTION.DOLLY,
               wheel: ACTION.DOLLY,
             }}
-            dollyToCursor={isStation}
+            dollyToCursor={false}
             dollySpeed={0.5}
           />
           <PolarGrid

--- a/client/src/components/Starmap/starmapStore.tsx
+++ b/client/src/components/Starmap/starmapStore.tsx
@@ -25,7 +25,7 @@ interface StarmapStore {
   currentSystem: number | null;
   setCurrentSystem: (systemId: number | null) => Promise<void>;
   currentSystemSet?: (value: any) => void;
-  cameraVerticalDistance: number;
+  cameraObjectDistance: number;
   cameraControls?: MutableRefObject<CameraControls | null>;
   followEntityId?: number | null;
   yDimensionIndex: number;
@@ -65,28 +65,28 @@ const createStarmapStore = () =>
       set({currentSystemSet, currentSystem: systemId});
       await promise;
     },
-    cameraVerticalDistance: 0,
+    cameraObjectDistance: 0,
     yDimensionIndex: 0,
     spawnShipTemplate: null,
+    cameraFocusPoint: new Vector3(),
     setCameraFocus: async position => {
-      const viewingMode = get().viewingMode;
       const cameraControls = get().cameraControls?.current;
-      if (viewingMode === "core") {
-        if (position && cameraControls) {
-          const camera = cameraControls.camera;
-          const up = camera.up.clone();
-          camera.up.set(0, 0, -1);
-          await cameraControls.setLookAt(
-            camera.position.x,
-            camera.position.y,
-            camera.position.z,
-            position.x,
-            position.y,
-            position.z,
-            true
-          );
-          camera.up.copy(up);
-        }
+      if (position && cameraControls) {
+        const camera = cameraControls.camera;
+        const up = camera.up.clone();
+        camera.up.set(0, 0, -1);
+        const distance = camera.position.distanceTo(position as Vector3);
+
+        await cameraControls.setLookAt(
+          position.x,
+          distance,
+          position.z,
+          position.x,
+          position.y,
+          position.z,
+          true
+        );
+        camera.up.copy(up);
       }
     },
     planetsHidden: false,
@@ -115,11 +115,12 @@ const distanceVector = new Vector3();
 export function useCalculateVerticalDistance() {
   const useStarmapStore = useGetStarmapStore();
   useFrame(({camera}) => {
-    const distance = camera.position.distanceTo(
-      distanceVector.set(camera.position.x, 0, camera.position.z)
-    );
+    useStarmapStore
+      .getState()
+      .cameraControls?.current?.getTarget(distanceVector);
+    const distance = camera.position.distanceTo(distanceVector);
     useStarmapStore.setState({
-      cameraVerticalDistance: distance,
+      cameraObjectDistance: distance,
     });
   });
 }

--- a/client/src/cores/StarmapCore/StarmapCoreContextMenu.tsx
+++ b/client/src/cores/StarmapCore/StarmapCoreContextMenu.tsx
@@ -73,13 +73,13 @@ export const StarmapCoreContextMenu = ({
     reference(virtualEl);
   }, parentRef);
 
-  const cameraVerticalDistance = useStarmapStore(
-    store => store.cameraVerticalDistance
+  const cameraObjectDistance = useStarmapStore(
+    store => store.cameraObjectDistance
   );
   useEffect(() => {
     // If the camera zooms in or out, hide the context menu.
     setOpen(false);
-  }, [cameraVerticalDistance]);
+  }, [cameraObjectDistance]);
 
   if (!open) return null;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of Changes

- Clicking on an object on Navigation now focuses the camera on that object, making it easier to zoom in and out on that object.
- Increases the number of points on orbit lines so there isn't a gap between the planet sprite and the line.
- Remove the `dollyToCursor` setting on the navigation controls.
- Make it so the camera focus changes based on the current distance between the camera and the object so the transition isn't so jarring.
- Renamed `cameraVerticalDistance` to `cameraObjectDistance` to make it's purpose more clear.
- Adds a QOTD

## Related Issue

<!--- Most pull requests should have linked issues, though small changes do not -->
<!--- This is to make sure every change has the opportunity to be discussed before being added to the project. -->
<!--- If suggesting a large new feature or change, please discuss it in an issue first -->
<!--- Small changes can be discussed in this pull request, so a related issue is not required -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- You can reference an issue by saying "Refs #123" or close an issue when this pull request is merged by saying "Closes #123"
<!--- Please link to the issue here: -->

Closes #501

## How do you know the changes work correctly?

<!-- Either describe the automated tests that you wrote -->
<!-- Or describe the steps that someone else can take to -->
<!-- check if your change does what it is supposed to -->
<!-- Eg. provide a test plan the reviewer can follow -->
Manual testing
On the navigation page, you should be able to rotate, zoom, and pan. Clicking on an object will make it so you can go right to the object, and then zoom in and out on that object. 
