### PR TITLE
feat: Make it possible to assign multiples of the same type of ship system to a ship.

### DIFF
--- a/client/src/cards/ComponentDemo/index.tsx
+++ b/client/src/cards/ComponentDemo/index.tsx
@@ -61,7 +61,7 @@ const SearchableListDemo = () => {
           },
         ]}
         selectedItem={selected}
-        setSelectedItem={id => {
+        setSelectedItem={({id}) => {
           setSelected(id);
         }}
       />

--- a/client/src/cards/Navigation/index.tsx
+++ b/client/src/cards/Navigation/index.tsx
@@ -110,7 +110,7 @@ function Waypoints() {
                 )}
               </span>
             )}
-            setSelectedItem={async id => {
+            setSelectedItem={async ({id}) => {
               const waypoint = waypoints.find(w => w.id === id);
               if (waypoint) {
                 if (

--- a/client/src/components/FlightQuickStart/MissionConfig.tsx
+++ b/client/src/components/FlightQuickStart/MissionConfig.tsx
@@ -29,8 +29,8 @@ const ShipConfig = () => {
     <div className="h-64 flex flex-col w-64">
       <SearchableList
         selectedItem={state.startingPointId}
-        setSelectedItem={item =>
-          dispatch({type: "startingPointId", startingPointId: item})
+        setSelectedItem={({id}) =>
+          dispatch({type: "startingPointId", startingPointId: id})
         }
         items={startingPoints.map(item => ({
           id: item,

--- a/client/src/components/FlightQuickStart/ShipConfig.tsx
+++ b/client/src/components/FlightQuickStart/ShipConfig.tsx
@@ -37,7 +37,7 @@ const ShipConfig = () => {
       <div className="h-64">
         <SearchableList
           selectedItem={state.shipId}
-          setSelectedItem={item => dispatch({type: "shipId", shipId: item})}
+          setSelectedItem={({id}) => dispatch({type: "shipId", shipId: id})}
           items={pluginShips.map(item => ({
             id: {shipId: item.name, pluginId: item.pluginName},
             label: item.name,

--- a/client/src/components/ui/SearchableList.tsx
+++ b/client/src/components/ui/SearchableList.tsx
@@ -15,7 +15,7 @@ interface SearchableListProps<
 > {
   items: L[];
   selectedItem?: ID | null;
-  setSelectedItem?: (item: ID) => void;
+  setSelectedItem?: (item: L) => void;
   renderItem?: (item: L) => JSX.Element;
   searchKeys?: OnlyString<keyof L>[];
   showSearchLabel?: boolean;
@@ -86,7 +86,7 @@ function SearchableList<
                       deepEqual(c.id, selectedItem) ? "selected" : ""
                     }`}
                     onClick={() => {
-                      setSelectedItem?.(c.id);
+                      setSelectedItem?.(c);
                     }}
                   >
                     {renderItem ? renderItem(c) : c.label}

--- a/client/src/pages/Config/Inventory/InventoryList.tsx
+++ b/client/src/pages/Config/Inventory/InventoryList.tsx
@@ -59,7 +59,7 @@ export function InventoryList() {
               }))}
               searchKeys={["name"]}
               selectedItem={inventoryId || null}
-              setSelectedItem={id => navigate(`${id}`)}
+              setSelectedItem={({id}) => navigate(`${id}`)}
               renderItem={c => (
                 <div className="flex justify-between items-center" key={c.id}>
                   <div>{c.name}</div>

--- a/client/src/pages/Config/PluginEdit.tsx
+++ b/client/src/pages/Config/PluginEdit.tsx
@@ -59,7 +59,7 @@ export default function PluginEdit() {
               }))}
               searchKeys={["name", "author", "tags"]}
               selectedItem={pluginId || null}
-              setSelectedItem={id => navigate(`/config/${id}`)}
+              setSelectedItem={({id}) => navigate(`/config/${id}`)}
               renderItem={c => (
                 <div className="flex justify-between items-center" key={c.id}>
                   <div>

--- a/client/src/pages/Config/ShipSystems/Basic.tsx
+++ b/client/src/pages/Config/ShipSystems/Basic.tsx
@@ -44,7 +44,7 @@ export function Basic() {
                 try {
                   const result = await q.plugin.systems.update.netSend({
                     pluginId,
-                    shipSystemId: systemId,
+                    systemId: systemId,
                     shipId,
                     shipPluginId,
                     name: e.target.value,
@@ -77,7 +77,7 @@ export function Basic() {
               onBlur={(e: any) =>
                 q.plugin.systems.update.netSend({
                   pluginId,
-                  shipSystemId: systemId,
+                  systemId: systemId,
                   shipId,
                   shipPluginId,
                   description: e.target.value,
@@ -99,7 +99,7 @@ export function Basic() {
                   if (system.tags.includes(tag)) return;
                   q.plugin.systems.update.netSend({
                     pluginId,
-                    shipSystemId: systemId,
+                    systemId: systemId,
                     tags: [...system.tags, tag],
                   });
                 }}
@@ -107,7 +107,7 @@ export function Basic() {
                   if (!system.tags.includes(tag)) return;
                   q.plugin.systems.update.netSend({
                     pluginId,
-                    shipSystemId: systemId,
+                    systemId: systemId,
                     shipId,
                     shipPluginId,
                     tags: system.tags.filter(t => t !== tag),

--- a/client/src/pages/Config/ShipSystems/OverrideResetButton.tsx
+++ b/client/src/pages/Config/ShipSystems/OverrideResetButton.tsx
@@ -28,7 +28,7 @@ export function OverrideResetButton({
       onClick={async () => {
         await q.plugin.systems.restoreOverride.netSend({
           pluginId,
-          shipSystemId: systemId,
+          systemId: systemId,
           shipId,
           shipPluginId,
           property,

--- a/client/src/pages/Config/ShipSystems/SettingsList.tsx
+++ b/client/src/pages/Config/ShipSystems/SettingsList.tsx
@@ -1,12 +1,25 @@
 import {q} from "@client/context/AppContext";
+import {useContext} from "react";
 import {useParams} from "react-router-dom";
 import {Link} from "react-router-dom";
+import {ShipPluginIdContext} from "../Ships/ShipSystemOverrideContext";
 
 export function SettingsList() {
   const params = useParams();
   const setting = params["*"]?.split("/")[1];
-  const {pluginId, systemId} = params as {pluginId: string; systemId: string};
-  const [system] = q.plugin.systems.get.useNetRequest({pluginId, systemId});
+  const {pluginId, systemId, shipId} = params as {
+    pluginId: string;
+    systemId: string;
+    shipId: string;
+  };
+  const shipPluginId = useContext(ShipPluginIdContext);
+
+  const [system] = q.plugin.systems.get.useNetRequest({
+    pluginId,
+    systemId,
+    shipId,
+    shipPluginId,
+  });
   const [availableShipSystems] = q.plugin.systems.available.useNetRequest();
   if (!system?.type) return null;
   const systemType = availableShipSystems.find(s => s.type === system.type);

--- a/client/src/pages/Config/ShipSystems/ShipSystemsList.tsx
+++ b/client/src/pages/Config/ShipSystems/ShipSystemsList.tsx
@@ -79,7 +79,7 @@ export function ShipSystemsList() {
               }))}
               searchKeys={["name", "category", "tags"]}
               selectedItem={systemId || null}
-              setSelectedItem={id => navigate(`${id}`)}
+              setSelectedItem={({id}) => navigate(`${id}`)}
               renderItem={c => (
                 <div className="flex justify-between items-center" key={c.id}>
                   <div>

--- a/client/src/pages/Config/ShipSystems/SystemConfigs/impulseEngines.tsx
+++ b/client/src/pages/Config/ShipSystems/SystemConfigs/impulseEngines.tsx
@@ -44,7 +44,7 @@ export default function ImpulseEngineConfig() {
                 try {
                   await q.plugin.systems.impulse.update.netSend({
                     pluginId,
-                    shipSystemId: systemId,
+                    systemId: systemId,
                     shipId,
                     shipPluginId,
                     cruisingSpeed: Number(e.target.value),
@@ -80,7 +80,7 @@ export default function ImpulseEngineConfig() {
                 try {
                   await q.plugin.systems.impulse.update.netSend({
                     pluginId,
-                    shipSystemId: systemId,
+                    systemId: systemId,
                     shipId,
                     shipPluginId,
                     emergencySpeed: Number(e.target.value),
@@ -118,7 +118,7 @@ export default function ImpulseEngineConfig() {
                 try {
                   await q.plugin.systems.impulse.update.netSend({
                     pluginId,
-                    shipSystemId: systemId,
+                    systemId: systemId,
                     shipId,
                     shipPluginId,
                     thrust: Number(e.target.value),

--- a/client/src/pages/Config/ShipSystems/SystemConfigs/inertialDampeners.tsx
+++ b/client/src/pages/Config/ShipSystems/SystemConfigs/inertialDampeners.tsx
@@ -44,7 +44,7 @@ export default function InertialDampenersConfig() {
                 try {
                   await q.plugin.systems.inertialDampeners.update.netSend({
                     pluginId,
-                    shipSystemId: systemId,
+                    systemId: systemId,
                     shipId,
                     shipPluginId,
                     dampening: Number(e.target.value),

--- a/client/src/pages/Config/ShipSystems/SystemConfigs/thrusters.tsx
+++ b/client/src/pages/Config/ShipSystems/SystemConfigs/thrusters.tsx
@@ -44,7 +44,7 @@ export default function ThrustersConfig() {
                 try {
                   await q.plugin.systems.thrusters.update.netSend({
                     pluginId,
-                    shipSystemId: systemId,
+                    systemId: systemId,
                     shipId,
                     shipPluginId,
                     directionMaxSpeed: Number(e.target.value),
@@ -80,7 +80,7 @@ export default function ThrustersConfig() {
                 try {
                   await q.plugin.systems.thrusters.update.netSend({
                     pluginId,
-                    shipSystemId: systemId,
+                    systemId: systemId,
                     shipId,
                     shipPluginId,
                     directionThrust: Number(e.target.value),
@@ -116,7 +116,7 @@ export default function ThrustersConfig() {
                 try {
                   await q.plugin.systems.thrusters.update.netSend({
                     pluginId,
-                    shipSystemId: systemId,
+                    systemId: systemId,
                     shipId,
                     shipPluginId,
                     rotationMaxSpeed: Number(e.target.value),
@@ -152,7 +152,7 @@ export default function ThrustersConfig() {
                 try {
                   await q.plugin.systems.thrusters.update.netSend({
                     pluginId,
-                    shipSystemId: systemId,
+                    systemId: systemId,
                     shipId,
                     shipPluginId,
                     rotationThrust: Number(e.target.value),

--- a/client/src/pages/Config/ShipSystems/SystemConfigs/warpEngines.tsx
+++ b/client/src/pages/Config/ShipSystems/SystemConfigs/warpEngines.tsx
@@ -42,7 +42,7 @@ export default function WarpEngines() {
                 try {
                   await q.plugin.systems.warp.update.netSend({
                     pluginId,
-                    shipSystemId: systemId,
+                    systemId: systemId,
                     shipId,
                     shipPluginId,
                     interstellarCruisingSpeed: Number(e.target.value),
@@ -78,7 +78,7 @@ export default function WarpEngines() {
                 try {
                   await q.plugin.systems.warp.update.netSend({
                     pluginId,
-                    shipSystemId: systemId,
+                    systemId: systemId,
                     shipId,
                     shipPluginId,
                     solarCruisingSpeed: Number(e.target.value),
@@ -116,7 +116,7 @@ export default function WarpEngines() {
                 try {
                   await q.plugin.systems.warp.update.netSend({
                     pluginId,
-                    shipSystemId: systemId,
+                    systemId: systemId,
                     shipId,
                     shipPluginId,
                     minSpeedMultiplier: Number(e.target.value),
@@ -154,7 +154,7 @@ export default function WarpEngines() {
                 try {
                   await q.plugin.systems.warp.update.netSend({
                     pluginId,
-                    shipSystemId: systemId,
+                    systemId: systemId,
                     shipId,
                     shipPluginId,
                     warpFactorCount: Math.round(Number(e.target.value)),

--- a/client/src/pages/Config/Ships/Basic.tsx
+++ b/client/src/pages/Config/Ships/Basic.tsx
@@ -147,11 +147,11 @@ export function Basic() {
                             })) || []
                           }
                           selectedItem={ship.theme}
-                          setSelectedItem={item => {
+                          setSelectedItem={({id}) => {
                             q.plugin.ship.update.netSend({
                               pluginId,
                               shipId,
-                              theme: item,
+                              theme: id,
                             });
                             close();
                           }}

--- a/client/src/pages/Config/Ships/ShipList.tsx
+++ b/client/src/pages/Config/Ships/ShipList.tsx
@@ -57,7 +57,7 @@ export function ShipList() {
               }))}
               searchKeys={["name", "category", "tags"]}
               selectedItem={shipId || null}
-              setSelectedItem={id => navigate(`${id}`)}
+              setSelectedItem={({id}) => navigate(`${id}`)}
               renderItem={c => (
                 <div className="flex justify-between items-center" key={c.id}>
                   <div>

--- a/client/src/pages/Config/Themes/ThemeList.tsx
+++ b/client/src/pages/Config/Themes/ThemeList.tsx
@@ -57,7 +57,7 @@ export function ThemeList() {
               }))}
               searchKeys={["name"]}
               selectedItem={themeId || null}
-              setSelectedItem={id => navigate(`${id}`)}
+              setSelectedItem={({id}) => navigate(`${id}`)}
               renderItem={c => (
                 <div className="flex justify-between items-center" key={c.id}>
                   <div>{c.name}</div>

--- a/client/src/pages/Config/data/systems/impulse.ts
+++ b/client/src/pages/Config/data/systems/impulse.ts
@@ -26,7 +26,7 @@ export const impulse = t.router({
     .input(
       z.object({
         pluginId: z.string(),
-        shipSystemId: z.string(),
+        systemId: z.string(),
         shipPluginId: z.string().optional(),
         shipId: z.string().optional(),
         cruisingSpeed: z.number().optional(),

--- a/client/src/pages/Config/data/systems/impulseEngines.test.ts
+++ b/client/src/pages/Config/data/systems/impulseEngines.test.ts
@@ -34,7 +34,7 @@ describe("impulse engines plugin input", () => {
 
     await router.plugin.systems.impulse.update({
       pluginId: "Test Plugin",
-      shipSystemId: "Test Impulse Engine",
+      systemId: "Test Impulse Engine",
       cruisingSpeed: 2000,
     });
     if (!(system instanceof ImpulseEnginesPlugin))
@@ -44,7 +44,7 @@ describe("impulse engines plugin input", () => {
     expect(system.emergencySpeed).toEqual(2000);
     await router.plugin.systems.impulse.update({
       pluginId: "Test Plugin",
-      shipSystemId: "Test Impulse Engine",
+      systemId: "Test Impulse Engine",
       emergencySpeed: 1000,
     });
     expect(system.emergencySpeed).toEqual(1000);
@@ -52,7 +52,7 @@ describe("impulse engines plugin input", () => {
     expect(system.thrust).toEqual(12500);
     await router.plugin.systems.impulse.update({
       pluginId: "Test Plugin",
-      shipSystemId: "Test Impulse Engine",
+      systemId: "Test Impulse Engine",
       thrust: 10000,
     });
     expect(system.thrust).toEqual(10000);

--- a/client/src/pages/Config/data/systems/index.ts
+++ b/client/src/pages/Config/data/systems/index.ts
@@ -99,7 +99,7 @@ export const systems = t.router({
     .input(
       z.object({
         pluginId: z.string(),
-        shipSystemId: z.string(),
+        systemId: z.string(),
         shipId: z.string().optional(),
         shipPluginId: z.string().optional(),
         name: z.string().optional(),
@@ -145,7 +145,7 @@ export const systems = t.router({
     .input(
       z.object({
         pluginId: z.string(),
-        shipSystemId: z.string(),
+        systemId: z.string(),
         shipId: z.string(),
         shipPluginId: z.string(),
         property: z.string(),

--- a/client/src/pages/Config/data/systems/inertialDampeners.ts
+++ b/client/src/pages/Config/data/systems/inertialDampeners.ts
@@ -26,7 +26,7 @@ export const inertialDampeners = t.router({
     .input(
       z.object({
         pluginId: z.string(),
-        shipSystemId: z.string(),
+        systemId: z.string(),
         shipPluginId: z.string().optional(),
         shipId: z.string().optional(),
         dampening: z.number().optional(),

--- a/client/src/pages/Config/data/systems/thrusters.ts
+++ b/client/src/pages/Config/data/systems/thrusters.ts
@@ -26,7 +26,7 @@ export const thrusters = t.router({
     .input(
       z.object({
         pluginId: z.string(),
-        shipSystemId: z.string(),
+        systemId: z.string(),
         shipPluginId: z.string().optional(),
         shipId: z.string().optional(),
         directionMaxSpeed: z.number().optional(),

--- a/client/src/pages/Config/data/systems/warp.ts
+++ b/client/src/pages/Config/data/systems/warp.ts
@@ -26,7 +26,7 @@ export const warp = t.router({
     .input(
       z.object({
         pluginId: z.string(),
-        shipSystemId: z.string(),
+        systemId: z.string(),
         shipPluginId: z.string().optional(),
         shipId: z.string().optional(),
         interstellarCruisingSpeed: z.number().optional(),

--- a/client/src/pages/Config/data/utils.ts
+++ b/client/src/pages/Config/data/utils.ts
@@ -35,14 +35,18 @@ export function getShipSystem({
   };
 }) {
   let override = {};
+  let systemId = input.systemId;
   if (input.shipPluginId) {
     const plugin = getPlugin(ctx, input.shipPluginId);
     const ship = plugin.aspects.ships.find(s => s.name === input.shipId);
     if (ship) {
       const system = ship.shipSystems.find(
-        s => s.systemId === input.systemId && s.pluginId === input.shipPluginId
+        s =>
+          s.id === input.systemId ||
+          (s.systemId === input.systemId && s.pluginId === input.shipPluginId)
       );
       if (system) {
+        systemId = system.systemId;
         if (!system.overrides) {
           system.overrides = {};
         }
@@ -52,9 +56,9 @@ export function getShipSystem({
   }
   const plugin = getPlugin(ctx, input.pluginId);
   const shipSystem = plugin.aspects.shipSystems.find(
-    system => system.name === input.systemId
+    system => system.name === systemId
   );
-  if (!shipSystem) throw new Error(`System not found: ${input.systemId}`);
+  if (!shipSystem) throw new Error(`System not found: ${systemId}`);
   const {plugin: sysPlugin, ...system} = shipSystem;
 
   return {
@@ -74,12 +78,12 @@ export function getShipSystemForInput<
   context: DataContext,
   {
     pluginId,
-    shipSystemId,
+    systemId,
     shipPluginId,
     shipId,
   }: {
     pluginId: string;
-    shipSystemId: string;
+    systemId: string;
     shipPluginId?: string;
     shipId?: string;
   }
@@ -93,18 +97,21 @@ export function getShipSystemForInput<
       throw new Error("Ship not found");
     }
     const system = ship.shipSystems.find(
-      s => s.systemId === shipSystemId && s.pluginId === shipPluginId
+      s =>
+        s.id === systemId ||
+        (s.systemId === systemId && s.pluginId === shipPluginId)
     );
     if (!system) {
       throw new Error("Ship system is not assigned to ship");
     }
+    systemId = system.systemId;
     if (!system.overrides) {
       system.overrides = {};
     }
     override = system.overrides;
   }
   const shipSystem = plugin.aspects.shipSystems.find(
-    s => s.name === shipSystemId
+    s => s.name === systemId
   ) as Sys;
   if (!shipSystem) {
     throw new Error("Ship system not found");

--- a/client/src/pages/FlightLobby.tsx
+++ b/client/src/pages/FlightLobby.tsx
@@ -219,7 +219,7 @@ function ClientAssignment() {
         <SearchableList
           showSearchLabel={false}
           selectedItem={selectedClient}
-          setSelectedItem={setSelectedClient}
+          setSelectedItem={({id}) => setSelectedClient(id)}
           items={clients
             .filter(c => c.shipId === null || c.shipId === undefined)
             .map(c => ({

--- a/server/src/classes/Plugins/Ship/index.ts
+++ b/server/src/classes/Plugins/Ship/index.ts
@@ -62,6 +62,7 @@ export default class ShipPlugin extends Aspect {
    * allowed.
    */
   shipSystems: {
+    id: string;
     systemId: string;
     pluginId: string;
     overrides?: Record<string, any>;

--- a/server/src/classes/Plugins/ShipSystems/BaseSystem.ts
+++ b/server/src/classes/Plugins/ShipSystems/BaseSystem.ts
@@ -21,6 +21,7 @@ export default class BaseShipSystemPlugin extends Aspect {
    * for this system
    */
   assets: {};
+  allowMultiple: boolean = false;
   constructor(params: Partial<BaseShipSystemPlugin>, plugin: BasePlugin) {
     const name = generateIncrementedName(
       params.name || `New ${params.type}`,

--- a/server/src/classes/Plugins/ShipSystems/Generic.ts
+++ b/server/src/classes/Plugins/ShipSystems/Generic.ts
@@ -5,6 +5,7 @@ import {ShipSystemFlags} from "./shipSystemTypes";
 export default class GenericSystemPlugin extends BaseShipSystemPlugin {
   static flags: ShipSystemFlags[] = ["efficiency", "heat", "power"];
   type: "generic" = "generic";
+  allowMultiple = true;
   // constructor(params: Partial<GenericSystemPlugin>, plugin: BasePlugin) {
   //   super(params, plugin);
   // }

--- a/server/src/inputs/plugins/shipSystems/inertialDampeners.test.ts
+++ b/server/src/inputs/plugins/shipSystems/inertialDampeners.test.ts
@@ -37,7 +37,7 @@ describe("inertial dampeners plugin input", () => {
     expect(system.dampening).toEqual(1);
     await router.plugin.systems.inertialDampeners.update({
       pluginId: "Test Plugin",
-      shipSystemId: "Test Inertial Dampeners",
+      systemId: "Test Inertial Dampeners",
       dampening: 2000,
     });
 

--- a/server/src/inputs/plugins/shipSystems/shipSystems.test.ts
+++ b/server/src/inputs/plugins/shipSystems/shipSystems.test.ts
@@ -62,7 +62,7 @@ describe("ship systems plugin input", () => {
 
     const updated = await router.plugin.systems.update({
       pluginId: "Test Plugin",
-      shipSystemId: shipSystem.shipSystemId,
+      systemId: shipSystem.shipSystemId,
       name: "New Name",
     });
 
@@ -75,7 +75,7 @@ describe("ship systems plugin input", () => {
     ).toEqual("");
     await router.plugin.systems.update({
       pluginId: "Test Plugin",
-      shipSystemId: updated.shipSystemId,
+      systemId: updated.shipSystemId,
       description: "New Description",
     });
   });

--- a/server/src/inputs/plugins/shipSystems/thrusters.test.ts
+++ b/server/src/inputs/plugins/shipSystems/thrusters.test.ts
@@ -32,7 +32,7 @@ describe("thrusters plugin input", () => {
     const system = dataContext.server.plugins[0].aspects.shipSystems[0];
     await router.plugin.systems.thrusters.update({
       pluginId: "Test Plugin",
-      shipSystemId: "Test Thrusters",
+      systemId: "Test Thrusters",
       directionMaxSpeed: 5,
     });
     if (!(system instanceof ThrustersPlugin)) throw new Error("Not thrusters");
@@ -41,7 +41,7 @@ describe("thrusters plugin input", () => {
     expect(system.rotationMaxSpeed).toEqual(5);
     await router.plugin.systems.thrusters.update({
       pluginId: "Test Plugin",
-      shipSystemId: "Test Thrusters",
+      systemId: "Test Thrusters",
       rotationMaxSpeed: 2,
     });
     expect(system.rotationMaxSpeed).toEqual(2);

--- a/server/src/inputs/plugins/shipSystems/warpEngines.test.ts
+++ b/server/src/inputs/plugins/shipSystems/warpEngines.test.ts
@@ -45,7 +45,7 @@ describe(`${testConfig.systemName} plugin input`, () => {
     // Test updating the system
     await router.plugin.systems.warp.update({
       pluginId: "Test Plugin",
-      shipSystemId: `Test ${testConfig.systemName}`,
+      systemId: `Test ${testConfig.systemName}`,
       interstellarCruisingSpeed: 1_000_000_000,
     });
     expect(system.interstellarCruisingSpeed).toEqual(1_000_000_000);
@@ -53,7 +53,7 @@ describe(`${testConfig.systemName} plugin input`, () => {
     expect(system.solarCruisingSpeed).toEqual(29_980_000);
     await router.plugin.systems.warp.update({
       pluginId: "Test Plugin",
-      shipSystemId: `Test ${testConfig.systemName}`,
+      systemId: `Test ${testConfig.systemName}`,
       solarCruisingSpeed: 1_000_000_000,
     });
     expect(system.solarCruisingSpeed).toEqual(1_000_000_000);
@@ -62,20 +62,20 @@ describe(`${testConfig.systemName} plugin input`, () => {
     await expect(
       router.plugin.systems.warp.update({
         pluginId: "Test Plugin",
-        shipSystemId: `Test ${testConfig.systemName}`,
+        systemId: `Test ${testConfig.systemName}`,
         warpFactorCount: 0.5,
       })
     ).rejects.toThrow();
     await expect(
       router.plugin.systems.warp.update({
         pluginId: "Test Plugin",
-        shipSystemId: `Test ${testConfig.systemName}`,
+        systemId: `Test ${testConfig.systemName}`,
         warpFactorCount: 3.5,
       })
     ).rejects.toThrow();
     await router.plugin.systems.warp.update({
       pluginId: "Test Plugin",
-      shipSystemId: `Test ${testConfig.systemName}`,
+      systemId: `Test ${testConfig.systemName}`,
       warpFactorCount: 3,
     });
     expect(system.warpFactorCount).toEqual(3);


### PR DESCRIPTION
## Description of Changes

- Refactors the way ship systems are assigned to ship plugins by giving each of them a unique ID
- Refactor the SearchableList component to provide all of the item values as part of the `setSelectedItem` callback.
- Categorize classes of ship system with an `allowMultiple` property.
- Add a plus button next to the system when assigning it to a ship to make it clear you can add multiples, when you can add multiples.

## Related Issue

<!--- Most pull requests should have linked issues, though small changes do not -->
<!--- This is to make sure every change has the opportunity to be discussed before being added to the project. -->
<!--- If suggesting a large new feature or change, please discuss it in an issue first -->
<!--- Small changes can be discussed in this pull request, so a related issue is not required -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- You can reference an issue by saying "Refs #123" or close an issue when this pull request is merged by saying "Closes #123"
<!--- Please link to the issue here: -->

Closes #480

## How do you know the changes work correctly?

<!-- Either describe the automated tests that you wrote -->
<!-- Or describe the steps that someone else can take to -->
<!-- check if your change does what it is supposed to -->
<!-- Eg. provide a test plan the reviewer can follow -->

Manual Testing:

- Create a generic system
- Go to a ship, to the systems config
- Assign the generic system multiple times.
