### PR TITLE
feat: Generate inventory for ships that don't have a deck map.

### DIFF
--- a/server/src/spawners/inventory.test.ts
+++ b/server/src/spawners/inventory.test.ts
@@ -104,8 +104,8 @@ describe("Inventory Generator", () => {
           "components": Object {
             "cargoContainer": CargoContainer {
               "contents": Object {
-                "Test torpedoCasing Cargo": 7,
-                "Test torpedoWarhead Cargo": 1,
+                "Test torpedoCasing Cargo": 3,
+                "Test torpedoWarhead Cargo": 5,
               },
               "volume": 100,
             },
@@ -202,15 +202,17 @@ describe("Inventory Generator", () => {
           "components": Object {
             "cargoContainer": CargoContainer {
               "contents": Object {
-                "Test forCrew Cargo": 1,
-                "Test medical Cargo": 4,
-                "Test probeCasing Cargo": 17,
-                "Test probeEquipment Cargo": 11,
-                "Test repair Cargo": 7,
-                "Test science Cargo": 7,
-                "Test security Cargo": 5,
-                "Test sparePart Cargo": 13,
-                "Test torpedoWarhead Cargo": 16,
+                "Test coolant Cargo": 3,
+                "Test forCrew Cargo": 4,
+                "Test fuel Cargo": 2,
+                "Test medical Cargo": 2,
+                "Test probeCasing Cargo": 13,
+                "Test probeEquipment Cargo": 13,
+                "Test repair Cargo": 4,
+                "Test science Cargo": 5,
+                "Test security Cargo": 3,
+                "Test sparePart Cargo": 10,
+                "Test torpedoWarhead Cargo": 8,
               },
               "volume": 1000,
             },
@@ -266,16 +268,12 @@ describe("Inventory Generator", () => {
           "components": Object {
             "cargoContainer": CargoContainer {
               "contents": Object {
-                "Test forCrew Cargo": 2,
-                "Test medical Cargo": 6,
-                "Test probeCasing Cargo": 12,
-                "Test probeEquipment Cargo": 9,
-                "Test repair Cargo": 8,
-                "Test science Cargo": 5,
-                "Test security Cargo": 7,
-                "Test sparePart Cargo": 9,
-                "Test torpedoCasing Cargo": 10,
-                "Test torpedoWarhead Cargo": 11,
+                "Test coolant Cargo": 4,
+                "Test fuel Cargo": 2,
+                "Test probeCasing Cargo": 17,
+                "Test probeEquipment Cargo": 19,
+                "Test torpedoCasing Cargo": 14,
+                "Test torpedoWarhead Cargo": 16,
               },
               "volume": 1000,
             },

--- a/server/src/spawners/ship.ts
+++ b/server/src/spawners/ship.ts
@@ -88,7 +88,11 @@ export function spawnShip(
   let extraEntities: Entity[] = [];
   // Initialize the ship map. For now, we'll just load the ship map onto a component of the ship.
   // In the future, rooms themselves might become entities.
-  if (entity.components.isPlayerShip) {
+  if (
+    entity.components.isPlayerShip &&
+    template.decks &&
+    template.decks?.length > 0
+  ) {
     const deckNodes =
       template.decks?.flatMap((deck, i) =>
         deck.nodes.map(n => ({...n, deckIndex: i, contents: {}}))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of Changes

- Don't assign crew-based inventory to ships that only have one room.
- Make sure ships that have 0 rooms are still assigned cargo of some kind.

## Related Issue

<!--- Most pull requests should have linked issues, though small changes do not -->
<!--- This is to make sure every change has the opportunity to be discussed before being added to the project. -->
<!--- If suggesting a large new feature or change, please discuss it in an issue first -->
<!--- Small changes can be discussed in this pull request, so a related issue is not required -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- You can reference an issue by saying "Refs #123" or close an issue when this pull request is merged by saying "Closes #123"
<!--- Please link to the issue here: -->

Closes #482

## How do you know the changes work correctly?

<!-- Either describe the automated tests that you wrote -->
<!-- Or describe the steps that someone else can take to -->
<!-- check if your change does what it is supposed to -->
<!-- Eg. provide a test plan the reviewer can follow -->

Automated Test
