### PR TITLE
Add alert level card

### DIFF
--- a/client/src/cards/AlertLevel/data.tsx
+++ b/client/src/cards/AlertLevel/data.tsx
@@ -1,0 +1,14 @@
+import {t} from "@server/init/t";
+import {pubsub} from "@server/init/pubsub";
+import {z} from "zod";
+
+export const alertLevel = t.router({
+    update: t.procedure
+      .input(z.object({level: z.string()}))
+      .send(({ctx, input}) => {
+        if (!ctx.ship) throw new Error("Ship not found");
+
+        ctx.ship.updateComponent('isShip', {alertLevel:input.level});
+        pubsub.publish.ship.get({shipId: ctx.ship.id});
+      })
+});

--- a/client/src/cards/AlertLevel/index.tsx
+++ b/client/src/cards/AlertLevel/index.tsx
@@ -46,18 +46,14 @@ const AlertLevel = () => {
       });
     }
     const clearDesc = () => {
-      alertLevelText.forEach((e) => {
-        if (e.number.toString() === ship.components.isShip?.alertLevel) {
-          setDescription("");
-        }
-      });
+      setDescription("");
     }
     return (
         <div className="flex flex-row h-full gap-4">
           <div className="flex-1">
-            <div className="flex flex-col justify-between h-full">
+            <div className="flex flex-col justify-between h-full gap-4">
               <Button 
-                className="btn-primary btn-lg"
+                className="btn-primary flex-1"
                 type="button"
                 onClick={() => updateLevel("5")}
                 onMouseEnter={() => displayDesc(5)}
@@ -66,7 +62,7 @@ const AlertLevel = () => {
                 Alert Condition 5
               </Button>
               <Button
-                className="btn-success btn-lg"
+                className="btn-success flex-1"
                 type="button"
                 onClick={() => updateLevel("4")}
                 onMouseEnter={() => displayDesc(4)}
@@ -75,7 +71,7 @@ const AlertLevel = () => {
                 Alert Condition 4
               </Button>
               <Button
-                className="btn-warning btn-lg"
+                className="btn-warning flex-1"
                 type="button"
                 onClick={() => updateLevel("3")}
                 onMouseEnter={() => displayDesc(3)}
@@ -84,7 +80,7 @@ const AlertLevel = () => {
                 Alert Condition 3
               </Button>
               <Button
-                className="btn-secondary btn-lg"
+                className="btn-secondary flex-1"
                 type="button"
                 onClick={() => updateLevel("2")}
                 onMouseEnter={() => displayDesc(2)}
@@ -93,7 +89,7 @@ const AlertLevel = () => {
                 Alert Condition 2
               </Button>
               <Button
-                className="btn-error btn-lg"
+                className="btn-error flex-1"
                 type="button"
                 onClick={() => updateLevel("1")}
                 onMouseEnter={() => displayDesc(1)}

--- a/client/src/cards/AlertLevel/index.tsx
+++ b/client/src/cards/AlertLevel/index.tsx
@@ -1,0 +1,112 @@
+import * as React from "react";
+import {q} from "@client/context/AppContext";
+import Button from "@thorium/ui/Button";
+
+const AlertLevel = () => {
+    const [ship] = q.ship.get.useNetRequest();
+    let [description, setDescription] = React.useState("");
+    const alertLevelText = [
+      {
+        number: 5,
+        text:
+          "This alert condition is used when the ship is at normal running status. The crew is on standard duty and the ship is in no danger.",
+      },
+      {
+        number: 4,
+        text:
+          "This alert condition is used when the station has a minor problem. All crew except damage control is on standard duty.",
+      },
+      {
+        number: 3,
+        text:
+          "This alert condition is used when the ship needs to be ready for a crisis. All off duty personnel are put on stand by status.",
+      },
+      {
+        number: 2,
+        text:
+          "This alert condition is used when the ship is in a dangerous situation, but is safe for the moment. All crew members are put on duty.",
+      },
+      {
+        number: 1,
+        text:
+          "This alert condition is used when the ship is in danger or under attack. All crew members are put on duty at battle stations.",
+      },
+    ];
+
+    const updateLevel = (newLevel: string) => {
+      q.alertLevel.update.netSend({
+        level: newLevel
+      });
+    }
+    const displayDesc = (level: number) => {
+      alertLevelText.forEach((e) => {
+        if (e.number === level) {
+          setDescription(e.text);
+        }
+      });
+    }
+    const clearDesc = () => {
+      alertLevelText.forEach((e) => {
+        if (e.number.toString() === ship.components.isShip?.alertLevel) {
+          setDescription("");
+        }
+      });
+    }
+    return (
+        <div className="flex flex-row h-full gap-4">
+          <div className="flex-1">
+            <div className="flex flex-col justify-between h-full">
+              <Button 
+                className="btn-primary btn-lg"
+                type="button"
+                onClick={() => updateLevel("5")}
+                onMouseEnter={() => displayDesc(5)}
+                onMouseLeave={() => clearDesc()}
+              >
+                Alert Condition 5
+              </Button>
+              <Button
+                className="btn-success btn-lg"
+                type="button"
+                onClick={() => updateLevel("4")}
+                onMouseEnter={() => displayDesc(4)}
+                onMouseLeave={() => clearDesc()}
+              >
+                Alert Condition 4
+              </Button>
+              <Button
+                className="btn-warning btn-lg"
+                type="button"
+                onClick={() => updateLevel("3")}
+                onMouseEnter={() => displayDesc(3)}
+                onMouseLeave={() => clearDesc()}
+              >
+                Alert Condition 3
+              </Button>
+              <Button
+                className="btn-secondary btn-lg"
+                type="button"
+                onClick={() => updateLevel("2")}
+                onMouseEnter={() => displayDesc(2)}
+                onMouseLeave={() => clearDesc()}
+              >
+                Alert Condition 2
+              </Button>
+              <Button
+                className="btn-error btn-lg"
+                type="button"
+                onClick={() => updateLevel("1")}
+                onMouseEnter={() => displayDesc(1)}
+                onMouseLeave={() => clearDesc()}
+              >
+                Alert Condition 1
+              </Button>
+            </div>
+          </div>
+          <div className="form-control flex flex-1 h-64">
+            <textarea className="textarea h-full w-full" value={description} disabled></textarea>
+          </div>
+        </div>
+    );
+};
+export default AlertLevel;

--- a/client/src/cards/AlertLevel/index.tsx
+++ b/client/src/cards/AlertLevel/index.tsx
@@ -2,36 +2,37 @@ import * as React from "react";
 import {q} from "@client/context/AppContext";
 import Button from "@thorium/ui/Button";
 
-const AlertLevel = () => {
+const alertLevelText = [
+  {
+    number: 5,
+    text:
+      "This alert condition is used when the ship is at normal running status. The crew is on standard duty and the ship is in no danger.",
+  },
+  {
+    number: 4,
+    text:
+      "This alert condition is used when the station has a minor problem. All crew except damage control is on standard duty.",
+  },
+  {
+    number: 3,
+    text:
+      "This alert condition is used when the ship needs to be ready for a crisis. All off duty personnel are put on stand by status.",
+  },
+  {
+    number: 2,
+    text:
+      "This alert condition is used when the ship is in a dangerous situation, but is safe for the moment. All crew members are put on duty.",
+  },
+  {
+    number: 1,
+    text:
+      "This alert condition is used when the ship is in danger or under attack. All crew members are put on duty at battle stations.",
+  },
+];
+
+export function AlertLevel() {
     const [ship] = q.ship.get.useNetRequest();
     let [description, setDescription] = React.useState("");
-    const alertLevelText = [
-      {
-        number: 5,
-        text:
-          "This alert condition is used when the ship is at normal running status. The crew is on standard duty and the ship is in no danger.",
-      },
-      {
-        number: 4,
-        text:
-          "This alert condition is used when the station has a minor problem. All crew except damage control is on standard duty.",
-      },
-      {
-        number: 3,
-        text:
-          "This alert condition is used when the ship needs to be ready for a crisis. All off duty personnel are put on stand by status.",
-      },
-      {
-        number: 2,
-        text:
-          "This alert condition is used when the ship is in a dangerous situation, but is safe for the moment. All crew members are put on duty.",
-      },
-      {
-        number: 1,
-        text:
-          "This alert condition is used when the ship is in danger or under attack. All crew members are put on duty at battle stations.",
-      },
-    ];
 
     const updateLevel = (newLevel: string) => {
       q.alertLevel.update.netSend({
@@ -105,4 +106,3 @@ const AlertLevel = () => {
         </div>
     );
 };
-export default AlertLevel;

--- a/client/src/cards/data.ts
+++ b/client/src/cards/data.ts
@@ -3,3 +3,4 @@ export {officersLog} from "./OfficersLog/data";
 export {navigation, waypoints} from "./Navigation/data";
 export {cargoControl} from "./CargoControl/data";
 export {viewscreen} from "./Viewscreen/data";
+export {alertLevel} from "./AlertLevel/data";

--- a/client/src/cards/index.ts
+++ b/client/src/cards/index.ts
@@ -5,3 +5,4 @@ export * from "./ComponentDemo";
 export * from "./Navigation";
 export * from "./CargoControl";
 export * from "./Viewscreen";
+export {default as AlertLevel} from "./AlertLevel";

--- a/client/src/cards/index.ts
+++ b/client/src/cards/index.ts
@@ -5,4 +5,4 @@ export * from "./ComponentDemo";
 export * from "./Navigation";
 export * from "./CargoControl";
 export * from "./Viewscreen";
-export {default as AlertLevel} from "./AlertLevel";
+export * from "./AlertLevel";

--- a/client/src/components/Station/StationLayout.tsx
+++ b/client/src/components/Station/StationLayout.tsx
@@ -16,7 +16,6 @@ const StationLayout = () => {
 
   const {account} = useThoriumAccount();
   if (!ship) return null;
-  // TODO November 29, 2021: Get the proper alert level and put it here.
   const alertLevel = ship.components.isShip?.alertLevel || "5";
 
   return (

--- a/client/src/components/Station/StationLayout.tsx
+++ b/client/src/components/Station/StationLayout.tsx
@@ -17,8 +17,7 @@ const StationLayout = () => {
   const {account} = useThoriumAccount();
   if (!ship) return null;
   // TODO November 29, 2021: Get the proper alert level and put it here.
-  // @ts-expect-error See above
-  const alertLevel = ship.alertLevel || "5";
+  const alertLevel = ship.components.isShip?.alertLevel || "5";
 
   return (
     <div

--- a/server/src/components/isShip.ts
+++ b/server/src/components/isShip.ts
@@ -16,6 +16,12 @@ export class IsShipComponent extends Component {
    */
   category: string = "Cruiser";
 
+  /**
+   * The current alert level of the ship. On a scale from 5 being "all clear" and 1 being "red alert".
+   * p represents a cloaked status.
+   */
+  alertLevel: string = "5";
+
   assets: Partial<{
     /**
      * The path to the logo image. Best if it's a square image. SVGs are preferred.

--- a/server/src/components/isShip.ts
+++ b/server/src/components/isShip.ts
@@ -1,5 +1,7 @@
 import {Component} from "./utils";
 
+type AlertLevel = "5" | "4" | "3" | "2" | "1" | "p";
+
 export class IsShipComponent extends Component {
   static id: "isShip" = "isShip";
   /**
@@ -20,7 +22,7 @@ export class IsShipComponent extends Component {
    * The current alert level of the ship. On a scale from 5 being "all clear" and 1 being "red alert".
    * p represents a cloaked status.
    */
-  alertLevel: string = "5";
+  alertLevel: AlertLevel = "5";
 
   assets: Partial<{
     /**

--- a/server/src/components/isShip.ts
+++ b/server/src/components/isShip.ts
@@ -1,7 +1,5 @@
 import {Component} from "./utils";
 
-type AlertLevel = "5" | "4" | "3" | "2" | "1" | "p";
-
 export class IsShipComponent extends Component {
   static id: "isShip" = "isShip";
   /**
@@ -22,7 +20,9 @@ export class IsShipComponent extends Component {
    * The current alert level of the ship. On a scale from 5 being "all clear" and 1 being "red alert".
    * p represents a cloaked status.
    */
-  alertLevel: AlertLevel = "5";
+  //It might be useful to create an AlertLevel type that has all of the possible alert levels
+  //type AlertLevel = "5" | "4" | "3" | "2" | "1" | "p";
+  alertLevel: string = "5";
 
   assets: Partial<{
     /**


### PR DESCRIPTION
## Description of Changes

Adding a card with the functionality to change the shipwide alert level.

-

## Related Issue

Closes #506 

## How do you know the changes work correctly?

Add the alert card to a station and navigate to it.
Clicking the alert levels should change the level and theme of each connected card.
Hovering over an alert level button should give a description of that alert level in the text box.

## Screenshots (if appropriate):
