### PR TITLE
fix: Send initial data stream when a client first requests it.

### DIFF
--- a/server/src/init/liveQuery.ts
+++ b/server/src/init/liveQuery.ts
@@ -69,7 +69,9 @@ export class Client<TRouter extends AnyRouter> extends ServerClient<TRouter> {
   isHost: boolean = false;
   name: string = randomNameGenerator();
 
-  public async sendDataStream(context: DataContext) {
+  public async sendDataStream() {
+    const context = getDataContext(this.id);
+
     if (!context?.flight || !this.connected) return;
     const entities = context.flight.ecs.entities
       .filter((entity: Entity) => {

--- a/server/src/systems/DataStreamSystem.ts
+++ b/server/src/systems/DataStreamSystem.ts
@@ -8,9 +8,8 @@ export class DataStreamSystem extends System {
     if (Date.now() - this.lastUpdate > 1000 / SERVER_FPS) {
       for (let clientId in this.ecs.server.clients) {
         const client = this.ecs.server.clients[clientId];
-        const dataContext = getDataContext(client.id);
-        if (!client || !dataContext) continue;
-        client.sendDataStream(dataContext);
+        if (!client) continue;
+        client.sendDataStream();
       }
       this.lastUpdate = Date.now();
     }

--- a/shared/live-query/adapters/fastify-adapter/index.ts
+++ b/shared/live-query/adapters/fastify-adapter/index.ts
@@ -371,6 +371,7 @@ export class ServerClient<TRouter extends AnyRouter> {
             const {id, path, params} = messageData;
             if (this.dataStreams.get(id)) return;
             this.dataStreams.set(id, {path, params});
+            this.sendDataStream();
             break;
           }
           case "dataStreamEnd": {
@@ -399,7 +400,7 @@ export class ServerClient<TRouter extends AnyRouter> {
   send(data: SocketMessages) {
     this.ee.emit("send", data);
   }
-  public async sendDataStream(context: inferRouterContext<TRouter>) {
+  public async sendDataStream() {
     // Filter the list of entities provided
   }
   connectionOpened() {}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of Changes

- Refactor how the data stream gets access to its inner context.
- Call the `sendDataStream` function when a client first connects.

## Related Issue

<!--- Most pull requests should have linked issues, though small changes do not -->
<!--- This is to make sure every change has the opportunity to be discussed before being added to the project. -->
<!--- If suggesting a large new feature or change, please discuss it in an issue first -->
<!--- Small changes can be discussed in this pull request, so a related issue is not required -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- You can reference an issue by saying "Refs #123" or close an issue when this pull request is merged by saying "Closes #123"
<!--- Please link to the issue here: -->

Closes #545

## How do you know the changes work correctly?

<!-- Either describe the automated tests that you wrote -->
<!-- Or describe the steps that someone else can take to -->
<!-- check if your change does what it is supposed to -->
<!-- Eg. provide a test plan the reviewer can follow -->

Manual test:
- Start a flight with the origin at Earth
- Make sure the flight is paused, so no data stream messages are sent.
- Go to the pilot card. The ship and planet should be positioned correctly and not right on top of each other.
