### PR TITLE
fix: Auto-claim host when first connecting.

### DIFF
--- a/client/src/components/QuoteOfTheDay.tsx
+++ b/client/src/components/QuoteOfTheDay.tsx
@@ -250,6 +250,8 @@ const quotes = [
   "Life's like a movie, write your own ending, keep believing, keep pretending.",
   "There's not a word yet for old friends who've just met.",
   "Life is made up of meetings and partings and that is the way of it.",
+  // Chantastic
+  "It's only dark until your eyes adjust.",
 ];
 
 const QuoteOfTheDay = () => {

--- a/server/src/init/liveQuery.ts
+++ b/server/src/init/liveQuery.ts
@@ -126,11 +126,25 @@ export class Client<TRouter extends AnyRouter> extends ServerClient<TRouter> {
     return {id, name, isHost};
   }
   connectionOpened(): void {
+    // Claim host if there isn't one already claimed
+    const ctx = getDataContext(this.id);
+    if (ctx) {
+      const hasHost = Object.values(ctx.server.clients).some(
+        client => client.isHost && client.connected
+      );
+      if (!hasHost) {
+        this.isHost = true;
+      }
+    }
     pubsub.publish.client.get({clientId: this.id});
     pubsub.publish.client.all();
+    pubsub.publish.thorium.hasHost();
   }
   connectionClosed(): void {
     pubsub.publish.client.get({clientId: this.id});
     pubsub.publish.client.all();
+    if (this.isHost) {
+      pubsub.publish.thorium.hasHost();
+    }
   }
 }

--- a/shared/live-query/adapters/fastify-adapter/index.ts
+++ b/shared/live-query/adapters/fastify-adapter/index.ts
@@ -234,7 +234,6 @@ export class ServerClient<TRouter extends AnyRouter> {
   ) {}
   encode(data: any) {
     return encode(data);
-    // return JSON.stringify(data);
   }
   public async initWebSocket(
     connection: SocketStream,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of Changes

- Automatically assign the first connected client to be the host.

## Related Issue

<!--- Most pull requests should have linked issues, though small changes do not -->
<!--- This is to make sure every change has the opportunity to be discussed before being added to the project. -->
<!--- If suggesting a large new feature or change, please discuss it in an issue first -->
<!--- Small changes can be discussed in this pull request, so a related issue is not required -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- You can reference an issue by saying "Refs #123" or close an issue when this pull request is merged by saying "Closes #123"
<!--- Please link to the issue here: -->

Closes #515 

## How do you know the changes work correctly?

<!-- Either describe the automated tests that you wrote -->
<!-- Or describe the steps that someone else can take to -->
<!-- check if your change does what it is supposed to -->
<!-- Eg. provide a test plan the reviewer can follow -->

Manual test. Connect a client. It should automatically be the host.
