### PR TITLE
fix: Navigation no longer crashes when transitioning to interstellar space

### DIFF
--- a/client/src/cards/Navigation/SolarSystemWrapper.tsx
+++ b/client/src/cards/Navigation/SolarSystemWrapper.tsx
@@ -23,22 +23,24 @@ import {q} from "@client/context/AppContext";
 export function SolarSystemWrapper() {
   const useStarmapStore = useGetStarmapStore();
   const currentSystem = useStarmapStore(store => store.currentSystem);
-
-  if (currentSystem === null) throw new Error("No current system");
-
   useEffect(() => {
     useStarmapStore.getState().currentSystemSet?.(currentSystem);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [useStarmapStore]);
 
-  const [system] = q.starmapCore.system.useNetRequest({
-    systemId: currentSystem,
-  });
+  const [system] = q.starmapCore.system.useNetRequest(
+    {
+      systemId: currentSystem!,
+    },
+    {keepPreviousData: true, enabled: currentSystem !== null}
+  );
   const [starmapEntities] = q.starmapCore.entities.useNetRequest({
     systemId: currentSystem,
   });
   const [ship] = q.navigation.ship.useNetRequest();
   const [waypoints] = q.waypoints.all.useNetRequest({systemId: currentSystem});
+
+  if (currentSystem === null) return null;
 
   return (
     <SolarSystemMap

--- a/server/src/systems/InterstellarTransitionSystem.ts
+++ b/server/src/systems/InterstellarTransitionSystem.ts
@@ -120,6 +120,7 @@ export class InterstellarTransitionSystem extends System {
         pubsub.publish.starmapCore.ship({shipId: entity.id});
 
         if (entity.components.isPlayerShip) {
+          pubsub.publish.navigation.ship({shipId: entity.id});
           pubsub.publish.ship.player({shipId: entity.id});
         }
       }
@@ -200,6 +201,7 @@ export class InterstellarTransitionSystem extends System {
         pubsub.publish.starmapCore.ship({shipId: entity.id});
 
         if (entity.components.isPlayerShip) {
+          pubsub.publish.navigation.ship({shipId: entity.id});
           pubsub.publish.ship.player({shipId: entity.id});
         }
         // // Update the warp engines


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of Changes

- Pubsub publishes to the navigation card when an interstellar transition takes place.
- Eliminates some potential errors with clever query handling.

## Related Issue

<!--- Most pull requests should have linked issues, though small changes do not -->
<!--- This is to make sure every change has the opportunity to be discussed before being added to the project. -->
<!--- If suggesting a large new feature or change, please discuss it in an issue first -->
<!--- Small changes can be discussed in this pull request, so a related issue is not required -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- You can reference an issue by saying "Refs #123" or close an issue when this pull request is merged by saying "Closes #123"
<!--- Please link to the issue here: -->
Closes #548

## How do you know the changes work correctly?
Manual test:
Start a flight, make sure the ship starts in a system
Activate the warp engines
Wait until the ship leaves the system
Watch what happens on the navigation screen. The view should transition to interstellar without crashing.
