### PR TITLE
fix: Add back in the "Reconnect to Server" dialogs

### DIFF
--- a/client/src/context/AppContext.tsx
+++ b/client/src/context/AppContext.tsx
@@ -10,11 +10,13 @@ import {getTabId} from "@thorium/tab-id";
 import {
   createLiveQueryReact,
   LiveQueryProvider,
+  useLiveQuery,
 } from "@thorium/live-query/client";
 import {AppRouter} from "@server/init/router";
 import {ThoriumAccountContextProvider} from "./ThoriumAccountContext";
 import {useSessionStorage} from "@client/hooks/useSessionStorage";
 import {randomFromList} from "@server/utils/randomFromList";
+import {Disconnected, Reconnecting} from "./ConnectionStatus";
 
 const Fallback: React.FC<FallbackProps> = ({error}) => {
   return (
@@ -57,6 +59,14 @@ async function getRequestContext() {
   return {id: await getTabId()};
 }
 
+function ConnectionStatus() {
+  const {reconnectionState} = useLiveQuery();
+
+  if (reconnectionState === "reconnecting") return <Reconnecting />;
+  if (reconnectionState === "disconnected") return <Disconnected />;
+  return null;
+}
+
 /**
  * A component to contain all of the context and wrapper components for the app.
  */
@@ -68,6 +78,7 @@ export default function AppContext({children}: {children: ReactNode}) {
         <ErrorBoundary FallbackComponent={Fallback}>
           <Suspense fallback={<LoadingSpinner />}>
             <LiveQueryProvider getRequestContext={getRequestContext}>
+              <ConnectionStatus />
               <ErrorBoundary FallbackComponent={Fallback}>
                 <Suspense fallback={<LoadingSpinner />}>
                   <ThoriumAccountContextProvider>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Related Issue

<!--- Most pull requests should have linked issues, though small changes do not -->
<!--- This is to make sure every change has the opportunity to be discussed before being added to the project. -->
<!--- If suggesting a large new feature or change, please discuss it in an issue first -->
<!--- Small changes can be discussed in this pull request, so a related issue is not required -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- You can reference an issue by saying "Refs #123" or close an issue when this pull request is merged by saying "Closes #123"
<!--- Please link to the issue here: -->
Closes #554

## How do you know the changes work correctly?

<!-- Either describe the automated tests that you wrote -->
<!-- Or describe the steps that someone else can take to -->
<!-- check if your change does what it is supposed to -->
<!-- Eg. provide a test plan the reviewer can follow -->

Turn on the client without the server
Open it up
The "Reconnect" dialog should appear.
Start the server
It should disappear as the client connects.

## Screenshots (if appropriate):
![Screenshot 2023-02-15 at 8 16 16 PM](https://user-images.githubusercontent.com/6558157/219235151-685557d9-6e98-48e4-9465-91337a54b22b.jpg)
