### PR TITLE
feat: Simulate impulse engine power consumption.

### DIFF
--- a/client/src/cards/Pilot/data.tsx
+++ b/client/src/cards/Pilot/data.tsx
@@ -15,12 +15,21 @@ export const pilot = t.router({
         const impulseEngines = getShipSystem(ctx, {
           systemType: "impulseEngines",
         });
+        let targetSpeed =
+          impulseEngines.components.isImpulseEngines?.targetSpeed || 0;
+        let cruisingSpeed =
+          impulseEngines.components.isImpulseEngines?.cruisingSpeed || 1;
+        if (impulseEngines.components.power) {
+          const {currentPower, maxSafePower, requiredPower} =
+            impulseEngines.components.power || {};
+          targetSpeed =
+            cruisingSpeed *
+            ((currentPower - requiredPower) / (maxSafePower - requiredPower));
+        }
         return {
           id: impulseEngines.id,
-          targetSpeed:
-            impulseEngines.components.isImpulseEngines?.targetSpeed || 0,
-          cruisingSpeed:
-            impulseEngines.components.isImpulseEngines?.cruisingSpeed || 1,
+          targetSpeed,
+          cruisingSpeed,
           emergencySpeed:
             impulseEngines.components.isImpulseEngines?.emergencySpeed || 1,
         };

--- a/server/src/systems/ImpulseSystem.ts
+++ b/server/src/systems/ImpulseSystem.ts
@@ -4,7 +4,16 @@ const SOFT_BRAKE_CONST = 5;
 
 /**
  * Determines the forward velocity applied by the impulse engines
- * based on the mass of the ship they are attached to
+ * based on the mass of the ship they are attached to.
+ *
+ * This works based on the power provided to the system.
+ * The powerDraw and currentPower have already been calculated
+ * by other systems. This system takes the currentPower value and
+ * reverses the operation to determine what the actual target speed
+ * is based on the power provided.
+ *
+ * It might be necessary to adjust the applied thrust as well, but
+ * it also might not be necessary.
  */
 export class ImpulseSystem extends System {
   WarpSystem?: System;
@@ -35,8 +44,17 @@ export class ImpulseSystem extends System {
     );
     const mass = ship.components.mass?.mass || 1;
 
-    const {thrust, targetSpeed, cruisingSpeed} =
+    let {thrust, targetSpeed, cruisingSpeed} =
       entity.components.isImpulseEngines;
+
+    if (entity.components.power) {
+      const {currentPower, maxSafePower, requiredPower} =
+        entity.components.power || {};
+      targetSpeed =
+        cruisingSpeed *
+        ((currentPower - requiredPower) / (maxSafePower - requiredPower));
+    }
+
     const appliedThrust = (targetSpeed / cruisingSpeed) * thrust;
 
     let acceleration = appliedThrust / mass;

--- a/server/src/systems/PowerDrawSystem.ts
+++ b/server/src/systems/PowerDrawSystem.ts
@@ -34,6 +34,11 @@ export class PowerDrawSystem extends System {
       case "impulseEngines": {
         if (!entity.components.isImpulseEngines) return;
         const {cruisingSpeed, targetSpeed} = entity.components.isImpulseEngines;
+        // If we're going faster than the cruising speed,
+        // draw as much power as possible
+        if (targetSpeed > cruisingSpeed) {
+          powerDraw = power.requestedPower;
+        }
         if (targetSpeed === 0) break;
         const impulseEngineUse = targetSpeed / cruisingSpeed;
         powerDraw =


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of Changes

- Set the target impulse speed based on the current power being supplied to the engines.
- Set the power draw to the highest possible power if the impulse engines are set to Emergency Impulse

## Related Issue

<!--- Most pull requests should have linked issues, though small changes do not -->
<!--- This is to make sure every change has the opportunity to be discussed before being added to the project. -->
<!--- If suggesting a large new feature or change, please discuss it in an issue first -->
<!--- Small changes can be discussed in this pull request, so a related issue is not required -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- You can reference an issue by saying "Refs #123" or close an issue when this pull request is merged by saying "Closes #123"
<!--- Please link to the issue here: -->

Closes #539
