### PR TITLE
fix: Improves inventory template lookup performance.

### DIFF
--- a/server/src/systems/FilterInventorySystem.ts
+++ b/server/src/systems/FilterInventorySystem.ts
@@ -1,7 +1,46 @@
+import {InventoryFlags} from "@server/classes/Plugins/Inventory/InventoryFlags";
 import {Entity, System} from "../utils/ecs";
 
 export class FilterInventorySystem extends System {
+  inventoryTemplates!: Record<
+    string,
+    {
+      name: string;
+      description?: string;
+      plural?: string;
+      volume: number;
+      continuous: boolean;
+      durability: number;
+      abundance: number;
+      flags: InventoryFlags;
+      assets: {image?: string};
+    }
+  >;
+  invalidated = false;
   test(entity: Entity) {
     return !!entity.components.isInventory;
+  }
+  private cacheInventoryTemplates() {
+    this.inventoryTemplates =
+      Object.fromEntries(
+        this.entities.map(entity => [
+          entity.components.identity?.name,
+          {...entity.components.identity, ...entity.components.isInventory},
+        ]) || []
+      ) || {};
+    this.invalidated = false;
+  }
+  addEntity(entity: Entity): void {
+    super.addEntity(entity);
+    this.invalidated = true;
+  }
+  removeEntity(entity: Entity): void {
+    super.removeEntity(entity);
+    this.invalidated = true;
+  }
+  getInventoryTemplates() {
+    if (!this.inventoryTemplates || this.invalidated)
+      this.cacheInventoryTemplates();
+    return this.inventoryTemplates;
   }
 }

--- a/server/src/utils/getInventoryTemplates.ts
+++ b/server/src/utils/getInventoryTemplates.ts
@@ -1,27 +1,12 @@
-import {InventoryFlags} from "@server/classes/Plugins/Inventory/InventoryFlags";
+import {FilterInventorySystem} from "@server/systems/FilterInventorySystem";
 import {ECS} from "./ecs";
 
 export function getInventoryTemplates(ecs?: ECS | null) {
   const inventorySystem = ecs?.systems.find(
     sys => sys.constructor.name === "FilterInventorySystem"
   );
-  return (Object.fromEntries(
-    inventorySystem?.entities.map(entity => [
-      entity.components.identity?.name,
-      {...entity.components.identity, ...entity.components.isInventory},
-    ]) || []
-  ) || {}) as Record<
-    string,
-    {
-      name: string;
-      description?: string;
-      plural?: string;
-      volume: number;
-      continuous: boolean;
-      durability: number;
-      abundance: number;
-      flags: InventoryFlags;
-      assets: {image?: string};
-    }
-  >;
+  if (inventorySystem instanceof FilterInventorySystem)
+    return inventorySystem.getInventoryTemplates();
+
+  return {};
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of Changes

- Optimizes the lookup of inventory templates by caching the result and including helpful cache invalidation

## Related Issue

<!--- Most pull requests should have linked issues, though small changes do not -->
<!--- This is to make sure every change has the opportunity to be discussed before being added to the project. -->
<!--- If suggesting a large new feature or change, please discuss it in an issue first -->
<!--- Small changes can be discussed in this pull request, so a related issue is not required -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- You can reference an issue by saying "Refs #123" or close an issue when this pull request is merged by saying "Closes #123"
<!--- Please link to the issue here: -->

Closes #582

## How do you know the changes work correctly?
Ran some benchmarks. Before: 0.8244ms to look up. After: 0.0177ms. That's 2% the original time, almost 2 orders of magnitude faster.
