### PR TITLE
fix: Restore the editor viewing mode when using the starmap editor.

### DIFF
--- a/client/src/pages/Config/Starmap/index.tsx
+++ b/client/src/pages/Config/Starmap/index.tsx
@@ -77,6 +77,13 @@ export default function StarMap() {
     pluginId: string;
   };
 
+  React.useEffect(() => {
+    useStarmapStore.getState().setCameraControlsEnabled(true);
+    useStarmapStore.setState({
+      viewingMode: "editor",
+    });
+  }, [useStarmapStore]);
+
   const selectedObjectIds = useStarmapStore(s => s.selectedObjectIds);
 
   const sceneRef = useRef<SceneRef>();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of Changes

- Set the viewing mode to `editor` and enable camera controls when visiting the starmap editor.

## Related Issue

<!--- Most pull requests should have linked issues, though small changes do not -->
<!--- This is to make sure every change has the opportunity to be discussed before being added to the project. -->
<!--- If suggesting a large new feature or change, please discuss it in an issue first -->
<!--- Small changes can be discussed in this pull request, so a related issue is not required -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- You can reference an issue by saying "Refs #123" or close an issue when this pull request is merged by saying "Closes #123"
<!--- Please link to the issue here: -->
Closes #587

## How do you know the changes work correctly?

<!-- Either describe the automated tests that you wrote -->
<!-- Or describe the steps that someone else can take to -->
<!-- check if your change does what it is supposed to -->
<!-- Eg. provide a test plan the reviewer can follow -->

Started a flight
Visited the viewscreen
Returned to the flight lobby and ended the flight
Went to the starmap editor
The controls worked correctly.

