### PR TITLE
fix: Improve rendering and transitioning the nebula background.

### DIFF
--- a/client/src/pages/Config/Starmap/index.tsx
+++ b/client/src/pages/Config/Starmap/index.tsx
@@ -143,11 +143,13 @@ const StarmapScene = forwardRef(function StarmapScene(props, ref) {
     <>
       <ambientLight intensity={0.2} />
       <pointLight position={[10, 10, 10]} />
-      <Routes>
-        <Route path="/:systemId" element={<SolarSystemWrapper />} />
-        <Route path="*" element={<InterstellarWrapper />} />
-      </Routes>
-      <Nebula />
+      <React.Suspense fallback={null}>
+        <Routes>
+          <Route path="/:systemId" element={<SolarSystemWrapper />} />
+          <Route path="*" element={<InterstellarWrapper />} />
+        </Routes>
+        <Nebula />
+      </React.Suspense>
     </>
   );
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of Changes

- Use a shader to transition the nebula backgrounds instead of two meshes. 

## Related Issue

<!--- Most pull requests should have linked issues, though small changes do not -->
<!--- This is to make sure every change has the opportunity to be discussed before being added to the project. -->
<!--- If suggesting a large new feature or change, please discuss it in an issue first -->
<!--- Small changes can be discussed in this pull request, so a related issue is not required -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- You can reference an issue by saying "Refs #123" or close an issue when this pull request is merged by saying "Closes #123"
<!--- Please link to the issue here: -->
Closes #572

## How do you know the changes work correctly?

<!-- Either describe the automated tests that you wrote -->
<!-- Or describe the steps that someone else can take to -->
<!-- check if your change does what it is supposed to -->
<!-- Eg. provide a test plan the reviewer can follow -->

Manual testing on Chrome (doesn't work in other browsers)
Go to the starmap editor, open up a system.
Click the randomize button on the skybox key and watch the sky transition.

