### PR TITLE
Do not mutate the warpSpeeds array

### DIFF
--- a/app/cards/Pilot/ImpulseControls.tsx
+++ b/app/cards/Pilot/ImpulseControls.tsx
@@ -313,7 +313,7 @@ export const ImpulseControls = ({ cardLoaded = true }) => {
 								},
 							)}
 						>
-							{warpSpeeds.reverse().map(({ label }, i, arr) => {
+							{warpSpeeds.slice().reverse().map(({ label }, i, arr) => {
 								const warpFactor = arr.length - i;
 								return (
 									<Button


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of Changes

- A recent change in 0398b3918fb3ffe8f91b5d34f8c6b67fa81283a8 appears to reverse the `warpSpeeds` on every render, causing the order of the warp speeds in the Pilot's console to reverse order unexpectedly.

## Related Issue

<!--- Most pull requests should have linked issues, though small changes do not -->
<!--- This is to make sure every change has the opportunity to be discussed before being added to the project. -->
<!--- If suggesting a large new feature or change, please discuss it in an issue first -->
<!--- Small changes can be discussed in this pull request, so a related issue is not required -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- You can reference an issue by saying "Refs #123" or close an issue when this pull request is merged by saying "Closes #123"
<!--- Please link to the issue here: -->

## How do you know the changes work correctly?

<!-- Either describe the automated tests that you wrote -->
<!-- Or describe the steps that someone else can take to -->
<!-- check if your change does what it is supposed to -->
<!-- Eg. provide a test plan the reviewer can follow -->

The order of the warp speeds no longer reverses unexpectedly when moving the slider.

## Screenshots (if appropriate):

On every render, the warp speeds would swap between these two images. With this change, it always remains like the first image.

<img width="475" height="369" alt="image" src="https://github.com/user-attachments/assets/45b9fd5d-881b-4a82-99cb-44ca4c6018cc" />

<img width="475" height="369" alt="image" src="https://github.com/user-attachments/assets/685d3486-1b8e-44a1-a0dd-b5517dc854aa" />
