### PR TITLE
fix: correctly apply damage efficiency to shield recharge rate

### DIFF
--- a/app/.server/systems/ShieldsSystem.ts
+++ b/app/.server/systems/ShieldsSystem.ts
@@ -13,9 +13,11 @@ export class ShieldsSystem extends System {
 			const { currentPower, powerLevels } = entity.components.power;
 			const requiredPower = powerLevels[0];
 			const { state, maxStrength, strength } = entity.components.isShields;
+			const efficiencyMultiplier = entity.components.damage?.efficiency ?? 1;
 			// Some space magic to make the shields more powerful.
 			// Increase this number to make shields recharge faster
-			let strengthToRecharge = currentPower * elapsedTimeHours * 10;
+			let strengthToRecharge =
+				currentPower * efficiencyMultiplier * elapsedTimeHours * 10;
 			if (state === "down" || currentPower < requiredPower) {
 				// Quickly drain shields when they are down
 				strengthToRecharge = (-maxStrength / SHIELD_DISCHARGE_TIME) * elapsed;

--- a/app/.server/systems/__test__/ShieldsSystem.test.ts
+++ b/app/.server/systems/__test__/ShieldsSystem.test.ts
@@ -159,6 +159,5 @@ describe("ShieldsSystem", () => {
 			ecs.update(18000); // 18 seconds
 			expect(shieldsEntity.components.isShields?.strength).toBe(3.5); // has recharged
 		});
-
 	});
 });

--- a/app/.server/systems/__test__/ShieldsSystem.test.ts
+++ b/app/.server/systems/__test__/ShieldsSystem.test.ts
@@ -143,11 +143,22 @@ describe("ShieldsSystem", () => {
 		it("shields will drain when there is insufficient power", () => {
 			const { ecs, shieldsEntity } = setupShieldsSystemTest({
 				shields: { maxStrength: 5, strength: 5, state: "up" },
-				power: { currentPower: 5, powerLevels: [10] },
+				power: { currentPower: 10, powerLevels: [20] },
 			});
 			expect(shieldsEntity.components.isShields?.strength).toBe(5);
 			ecs.update(1000); // 1 second
 			expect(shieldsEntity.components.isShields?.strength).toBe(4); // has drained
 		});
+
+		it("shields will still charge even if powerLevels is an empty array", () => {
+			const { ecs, shieldsEntity } = setupShieldsSystemTest({
+				shields: { maxStrength: 5, strength: 3, state: "up" },
+				power: { currentPower: 10, powerLevels: [] },
+			});
+			expect(shieldsEntity.components.isShields?.strength).toBe(3);
+			ecs.update(18000); // 18 seconds
+			expect(shieldsEntity.components.isShields?.strength).toBe(3.5); // has recharged
+		});
+
 	});
 });

--- a/app/.server/systems/__test__/ShieldsSystem.test.ts
+++ b/app/.server/systems/__test__/ShieldsSystem.test.ts
@@ -1,0 +1,153 @@
+import { createMockDataContext } from "@thorium/utils/.server/createMockDataContext";
+import { ECS, Entity } from "@thorium/utils/ecs";
+import { describe, expect, it } from "vitest";
+import { ShieldsSystem } from "../ShieldsSystem";
+
+/**
+ * Helper function to create an ECS instance with a ShieldsSystem and a ship entity
+ * that has isShields, power, and damage components.
+ * @param shields - Initial values for the isShields component
+ * @param power - Initial values for the power component
+ * @param damage - Initial values for the damage component
+ * @returns An object containing the ECS instance, ShieldsSystem, shields entity, and ship entity
+ */
+function setupShieldsSystemTest({
+	shields,
+	power,
+	damage,
+}: {
+	shields?: {
+		maxStrength?: number;
+		state?: "up" | "down";
+		strength?: number;
+	};
+	power?: {
+		currentPower?: number;
+		powerLevels?: number[];
+	};
+	damage?: {
+		efficiency?: number;
+	};
+} = {}) {
+	const mockDataContext = createMockDataContext();
+	const ecs = new ECS(mockDataContext.server);
+
+	const shieldsSystem = new ShieldsSystem();
+	ecs.addSystem(shieldsSystem);
+
+	const shipEntity = new Entity();
+	shipEntity.addComponent("isShip");
+	shipEntity.addComponent("shipSystems");
+	ecs.addEntity(shipEntity);
+
+	const shieldsEntity = new Entity();
+	shieldsEntity.addComponent("isShipSystem", {
+		type: "shields",
+		shipId: shipEntity.id,
+	});
+	shieldsEntity.addComponent("isShields", shields);
+	shieldsEntity.addComponent("power", power);
+	shieldsEntity.addComponent("damage", damage);
+	shipEntity.components.shipSystems?.shipSystems.set(shieldsEntity.id, {});
+	ecs.addEntity(shieldsEntity);
+
+	return { ecs, shieldsSystem, shieldsEntity, shipEntity };
+}
+
+describe("ShieldsSystem", () => {
+	describe("test()", () => {
+		it("returns true for entities with isShields component", () => {
+			const { shieldsSystem, shieldsEntity } = setupShieldsSystemTest();
+			expect(shieldsSystem.test(shieldsEntity)).toBe(true);
+		});
+
+		it("returns false for entities without isShields component", () => {
+			const { shieldsSystem, shipEntity } = setupShieldsSystemTest();
+			const randomEntity = new Entity();
+			expect(shieldsSystem.test(shipEntity)).toBe(false);
+			expect(shieldsSystem.test(randomEntity)).toBe(false);
+		});
+	});
+
+	describe("update()", () => {
+		it("shields remain at full power when already charged", () => {
+			const { ecs, shieldsEntity } = setupShieldsSystemTest({
+				shields: { maxStrength: 5, strength: 5, state: "up" },
+			});
+			expect(shieldsEntity.components.isShields?.strength).toBe(5);
+			ecs.update(1000); // 1 second
+			expect(shieldsEntity.components.isShields?.strength).toBe(5); // remains at max
+		});
+
+		it("shields recharge when not at full strength", () => {
+			const { ecs, shieldsEntity } = setupShieldsSystemTest({
+				shields: { maxStrength: 5, strength: 3, state: "up" },
+				power: { currentPower: 10, powerLevels: [10] },
+			});
+			expect(shieldsEntity.components.isShields?.strength).toBe(3);
+			ecs.update(18000); // 18 seconds
+			expect(shieldsEntity.components.isShields?.strength).toBe(3.5); // has recharged
+			ecs.update(18000); // 18 more seconds
+			expect(shieldsEntity.components.isShields?.strength).toBe(4); // has recharged more
+		});
+
+		it("shields recharge faster when at higher power", () => {
+			const { ecs, shieldsEntity } = setupShieldsSystemTest({
+				shields: { maxStrength: 5, strength: 3, state: "up" },
+				power: { currentPower: 20, powerLevels: [20] },
+			});
+			expect(shieldsEntity.components.isShields?.strength).toBe(3);
+			ecs.update(18000); // 18 seconds
+			expect(shieldsEntity.components.isShields?.strength).toBe(4); // has recharged
+			ecs.update(18000); // 18 seconds
+			expect(shieldsEntity.components.isShields?.strength).toBe(5); // has recharged more
+		});
+
+		it("shields recharge at lower rate when damaged", () => {
+			const { ecs, shieldsEntity } = setupShieldsSystemTest({
+				shields: { maxStrength: 5, strength: 3, state: "up" },
+				power: { currentPower: 10, powerLevels: [10] },
+				damage: { efficiency: 0.8 },
+			});
+			expect(shieldsEntity.components.isShields?.strength).toBe(3);
+			ecs.update(18000); // 18 seconds
+			expect(shieldsEntity.components.isShields?.strength).toBe(3.4); // has recharged at lower rate
+			ecs.update(18000); // 18 seconds
+			expect(shieldsEntity.components.isShields?.strength).toBe(3.8); // has recharged more at lower rate
+		});
+
+		it("shields drain quickly when down", () => {
+			const { ecs, shieldsEntity } = setupShieldsSystemTest({
+				shields: { maxStrength: 5, strength: 5, state: "down" },
+				power: { currentPower: 10, powerLevels: [10] },
+			});
+			expect(shieldsEntity.components.isShields?.strength).toBe(5);
+			ecs.update(1000); // 1 second
+			expect(shieldsEntity.components.isShields?.strength).toBe(4); // has drained
+			ecs.update(1000); // 1 more second
+			expect(shieldsEntity.components.isShields?.strength).toBe(3); // has drained more
+			ecs.update(3000); // 3 more seconds
+			expect(shieldsEntity.components.isShields?.strength).toBe(0); // has drained completely to 0
+		});
+
+		it("shields will not drain below 0", () => {
+			const { ecs, shieldsEntity } = setupShieldsSystemTest({
+				shields: { maxStrength: 5, strength: 0, state: "down" },
+				power: { currentPower: 10, powerLevels: [10] },
+			});
+			expect(shieldsEntity.components.isShields?.strength).toBe(0);
+			ecs.update(1000); // 1 second
+			expect(shieldsEntity.components.isShields?.strength).toBe(0); // remains at 0
+		});
+
+		it("shields will drain when there is insufficient power", () => {
+			const { ecs, shieldsEntity } = setupShieldsSystemTest({
+				shields: { maxStrength: 5, strength: 5, state: "up" },
+				power: { currentPower: 5, powerLevels: [10] },
+			});
+			expect(shieldsEntity.components.isShields?.strength).toBe(5);
+			ecs.update(1000); // 1 second
+			expect(shieldsEntity.components.isShields?.strength).toBe(4); // has drained
+		});
+	});
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of Changes

- Multiplies the recharge rate by the shield's damage efficiency. Damaged shields will recharge slower.
- Adds tests for ShieldsSystem.

## Related Issue

Closes #634 

<!--- Most pull requests should have linked issues, though small changes do not -->
<!--- This is to make sure every change has the opportunity to be discussed before being added to the project. -->
<!--- If suggesting a large new feature or change, please discuss it in an issue first -->
<!--- Small changes can be discussed in this pull request, so a related issue is not required -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- You can reference an issue by saying "Refs #123" or close an issue when this pull request is merged by saying "Closes #123"
<!--- Please link to the issue here: -->

## How do you know the changes work correctly?

- Added `ShieldsSystem.test.ts` which tests the behavior of the ShieldsSystem, including the new recharge efficiency multiplier

<!-- Either describe the automated tests that you wrote -->
<!-- Or describe the steps that someone else can take to -->
<!-- check if your change does what it is supposed to -->
<!-- Eg. provide a test plan the reviewer can follow -->

## Screenshots (if appropriate):
