### PR TITLE
Issue 729 - adding returns to some procedures to remove value is not JSON serializable errors

### DIFF
--- a/app/.server/data/client.ts
+++ b/app/.server/data/client.ts
@@ -320,6 +320,7 @@ export const client = t.router({
 				pubsub.publish.client.all();
 				pubsub.publish.client.get({ clientId: input.clientId });
 			}
+			return null;
 		}),
 	testStation: t.procedure
 		.input(z.object({ clientId: z.string(), component: z.string().nullable() }))

--- a/app/cards/DamageReports/data.server.ts
+++ b/app/cards/DamageReports/data.server.ts
@@ -74,6 +74,7 @@ export const damageReports = t.router({
 					};
 				}
 			}
+			return null;
 		}),
 	diagnosticCreate: t.procedure
 		.input(
@@ -164,6 +165,7 @@ export const damageReports = t.router({
 			pubsub.publish.damageReports.systemDiagnostic({
 				systemId: diagnostic.components.diagnostic?.targetSystemId || -1,
 			});
+			return null;
 		}),
 	damageReports: t.procedure
 		.input(z.object({ shipId: z.number() }))
@@ -338,6 +340,7 @@ export const damageReports = t.router({
 			pubsub.publish.damageReports.damageReports({
 				shipId: damageReport.components.damageReport?.shipId || -1,
 			});
+			return null;
 		}),
 	applyDamageReportMetrics: t.procedure
 		.meta({

--- a/app/cards/Navigation/data.server.tsx
+++ b/app/cards/Navigation/data.server.tsx
@@ -464,6 +464,7 @@ export const waypoints = t.router({
 			pubsub.publish.waypoints.all({
 				shipId,
 			});
+			return null;
 		}),
 });
 

--- a/app/cards/SystemsMonitor/data.server.ts
+++ b/app/cards/SystemsMonitor/data.server.ts
@@ -134,7 +134,6 @@ export const systemsMonitor = t.router({
 						shipId: entity.components.isShipSystem.shipId,
 					},
 			)
-
 			.request(({ ctx, input }) => {
 				const systems: {
 					id: number;
@@ -224,6 +223,7 @@ export const systemsMonitor = t.router({
 					// Update the output megawatts of the phasers
 					pubsub.publish.targeting.phasers.list({ shipId });
 				}
+				return null;
 			}),
 		addPowerSource: t.procedure
 			.input(
@@ -295,6 +295,7 @@ export const systemsMonitor = t.router({
 					// Update the output megawatts of the phasers
 					pubsub.publish.targeting.phasers.list({ shipId });
 				}
+				return null;
 			}),
 	}),
 	stream: t.procedure


### PR DESCRIPTION
## Description of Changes

- Added return null to some procedures that were returning undefined by default.

## Related Issue
[Issue 729](https://github.com/Thorium-Sim/thorium-nova/issues/729)

## How do you know the changes work correctly?

To Reproduce Steps to reproduce the behavior:

1. Checkout branch develop
2. Start server: bun run dev
3. Navigate to localhost:3000
4. Click start flight
5. Accept defaults, click Next
6. Accept defaults (Sandbox, Earth), click Start
7. Assign client to pilot station
8. Click go to station
9. Do not see error: in the terminal running the server, see error number one listed in issue. Looks like about 50 or so times.
10. Enter a name and click Login
11. Click the navigation icon to go to the navigation station
12. Click on earth
13. Click Set Waypoint
14. Click on the Earth Waypoint listed under search, on the delete icon
15. Flash message does not appear on screen stating there is an error
16. In the terminal running the server, do not see the error message number two from issue.
17. Click the logout icon in the bottom right of the station screen
18. In the terminal running the server, do not see the error message number three from issue.
19. Log back in
20. Click the Systems Monitor icon to go to the systems monitor station
21. Click on the top Fusion Reactor to select it (or any of the power sources: reactor, battery, capacitor)
22. Click on the Allocate Power icon for the top battery (or any system)
23. Do not see a flash message regarding an error with data not JSON serializable
24. In the terminal running the server do not see error message number four from issue.
25. Click to select a Power Source
26. Click a corresponding green square in any system
27. In the terminal running the server do not see error message number five from issue.

## Screenshots (if appropriate):
