### PR TITLE
add publish alert status to stations

### DIFF
--- a/app/cards/AlertLevel/data.server.tsx
+++ b/app/cards/AlertLevel/data.server.tsx
@@ -25,6 +25,7 @@ export const alertLevel = t.router({
 			if (!ship?.components.isShip) throw new Error("Ship not found");
 
 			ship.updateComponent("isShip", { alertLevel: input.alertLevel });
+			pubsub.publish.ship.player({ shipId: ship.id });
 			pubsub.publish.ship.get({ shipId: ship.id });
 			pubsub.publish.starmapCore.object({ objectId: ship.id });
 


### PR DESCRIPTION
## Description of Changes

When an alert is set on the flight director starmap screen, it wasn't getting published.

## Related Issue

## How do you know the changes work correctly?

After making the change, I verified that the alert now publishes instantly instead of requiring a refresh.

## Screenshots (if appropriate):
