### PR TITLE
4 Bug Fixes, Related to Pilot, Velocity, and Flight Director Starmap

### DIFF
--- a/app/.server/systems/InterstellarTransitionSystem.ts
+++ b/app/.server/systems/InterstellarTransitionSystem.ts
@@ -128,6 +128,7 @@ export class InterstellarTransitionSystem extends System {
 				if (entity.components.isPlayerShip) {
 					pubsub.publish.navigation.ship({ shipId: entity.id });
 					pubsub.publish.ship.player({ shipId: entity.id });
+					pubsub.publish.ship.players();
 				}
 			}
 		} else {
@@ -227,6 +228,7 @@ export class InterstellarTransitionSystem extends System {
 				if (entity.components.isPlayerShip) {
 					pubsub.publish.navigation.ship({ shipId: entity.id });
 					pubsub.publish.ship.player({ shipId: entity.id });
+					pubsub.publish.ship.players();
 				}
 				// // Update the warp engines
 				// const warpEngines = this.ecs.entities.find(

--- a/app/.server/systems/PhysicsMovementSystem.ts
+++ b/app/.server/systems/PhysicsMovementSystem.ts
@@ -242,9 +242,10 @@ export class PhysicsMovementSystem extends System {
 
 			/**
 			 * Warp Engines
+			 * They ignore mass, so we set the velocity directly.
 			 */
 			if (warpEngines?.components.isWarpEngines?.forwardVelocity) {
-				velocityVector.add(
+				velocityVector.copy(
 					tempObj.localToWorld(
 						tempVector.set(
 							0,
@@ -292,6 +293,10 @@ export class PhysicsMovementSystem extends System {
 				}
 			}
 			/**
+			 * Compute forward velocity (km/s) before unit conversion
+			 */
+			const forwardVelocity = velocityVector.length();
+			/**
 			 * Translate velocity to LightMinutes if we're in interstellar space
 			 */
 			if (isInterstellarSpace) {
@@ -305,6 +310,7 @@ export class PhysicsMovementSystem extends System {
 					x: velocityVector.x,
 					y: velocityVector.y,
 					z: velocityVector.z,
+					forwardVelocity,
 				});
 				const { x, y, z } = entity.components.position || { x: 0, y: 0, z: 0 };
 				tempVector.set(x, y, z);
@@ -436,7 +442,7 @@ export class PhysicsMovementSystem extends System {
 			const body = world.bodies.get(bodyHandle);
 			if (!body) continue;
 			// No need to update fixed bodies.
-			if (body.bodyType() === RAPIER.RigidBodyType.Fixed) return;
+			if (body.bodyType() === RAPIER.RigidBodyType.Fixed) continue;
 
 			{
 				const translation = body.translation();

--- a/app/cores/StarmapCore/data.server.tsx
+++ b/app/cores/StarmapCore/data.server.tsx
@@ -124,7 +124,7 @@ export const starmapCore = t.router({
 					components.isShip &&
 					((typeof input?.systemId === "number" &&
 						components.position?.parentId === input.systemId) ||
-						(input?.systemId === undefined &&
+						(input?.systemId == null &&
 							components.position?.type === "interstellar"))
 				) {
 					data.push({
@@ -196,7 +196,7 @@ export const starmapCore = t.router({
 					components.isTorpedo &&
 					((typeof input?.systemId === "number" &&
 						components.position?.parentId === input.systemId) ||
-						(input?.systemId === undefined &&
+						(input?.systemId == null &&
 							components.position?.type === "interstellar"))
 				) {
 					if (

--- a/app/cores/StarmapCore/index.tsx
+++ b/app/cores/StarmapCore/index.tsx
@@ -722,9 +722,12 @@ function CanvasWrapper() {
 	const useStarmapStore = useGetStarmapStore();
 	const currentSystem = useStarmapStore((store) => store.currentSystem);
 	q.starmapCore.stream.useDataStream({ systemId: currentSystem });
-	const [starmapShips] = q.starmapCore.ships.useNetRequest({
-		systemId: currentSystem,
-	});
+	const [starmapShips] = q.starmapCore.ships.useNetRequest(
+		{
+			systemId: currentSystem,
+		},
+		{ placeholderData: keepPreviousData },
+	);
 	const { interpolate } = useLiveQuery();
 
 	const cameraRef = useRef<PerspectiveCamera>(undefined);
@@ -796,9 +799,12 @@ export function InterstellarWrapper() {
 	const currentSystem = useStarmapStore((store) => store.currentSystem);
 	const isViewscreen = useStarmapStore((store) => store.viewingMode);
 
-	const [starmapShips] = q.starmapCore.ships.useNetRequest({
-		systemId: currentSystem,
-	});
+	const [starmapShips] = q.starmapCore.ships.useNetRequest(
+		{
+			systemId: currentSystem,
+		},
+		{ placeholderData: keepPreviousData },
+	);
 	const [starmapSystems] = q.starmapCore.systems.useNetRequest();
 
 	return (
@@ -853,7 +859,7 @@ export function SolarSystemWrapper() {
 	const useStarmapStore = useGetStarmapStore();
 	const currentSystem = useStarmapStore((store) => store.currentSystem);
 
-	if (currentSystem === null) throw new Error("No current system");
+	if (currentSystem === null) return null;
 	const [system] = q.starmapCore.system.useNetRequest({
 		systemId: currentSystem,
 	});

--- a/app/cores/StarmapCore/index.tsx
+++ b/app/cores/StarmapCore/index.tsx
@@ -787,7 +787,9 @@ function CanvasWrapper() {
 				{currentSystem === null ? (
 					<InterstellarWrapper />
 				) : (
-					<SolarSystemWrapper />
+					<ErrorBoundary fallback={null}>
+						<SolarSystemWrapper />
+					</ErrorBoundary>
 				)}
 			</StarmapCanvas>
 			{dragPosition && <DragSelection {...dragPosition} />}
@@ -859,7 +861,7 @@ export function SolarSystemWrapper() {
 	const useStarmapStore = useGetStarmapStore();
 	const currentSystem = useStarmapStore((store) => store.currentSystem);
 
-	if (currentSystem === null) return null;
+	if (currentSystem === null) throw new Error("No current system");
 	const [system] = q.starmapCore.system.useNetRequest({
 		systemId: currentSystem,
 	});


### PR DESCRIPTION
## Description of Changes

 Bug 1: Forward velocity display freezes at 46.1C when changing warp factors

  File: app/.server/systems/PhysicsMovementSystem.ts
  - Root cause: The simple physics path (used when not in a collision physics world) never computed forwardVelocity, so the velocity display component showed a stale value.
  - Fix: Added const forwardVelocity = velocityVector.length() before the KM_TO_LM unit conversion, and included it in the velocity component update.

  Bug 2: Forward velocity exceeds target warp speed and climbs indefinitely

  File: app/.server/systems/PhysicsMovementSystem.ts
  - Root cause: At warp 4 (74.3C), the ship exceeds the isHighSpeed threshold (solarCruisingSpeed/2 ≈ 50C) and falls through to the simple physics path. In that path, the warp velocity was added to the existing velocity each frame via velocityVector.add(), compounding indefinitely. The collision physics path correctly sets the velocity via body.setLinvel().
  - Fix: Changed velocityVector.add() to velocityVector.copy() so warp velocity sets the velocity directly, matching the collision physics behavior. The WarpSystem already handles acceleration curves and clamping to maxVelocity.

  Bug 3: Flight director starmap flashes green repeatedly when ship is in interstellar space

  Files: app/.server/systems/InterstellarTransitionSystem.ts, app/cores/StarmapCore/index.tsx,
  app/cores/StarmapCore/data.server.tsx
  - Root cause: When a ship transitions between solar and interstellar space, InterstellarTransitionSystem published ship.player but not ship.players. The StarmapCoreMenubar reads ship.players to get currentSystem, so it used stale data after transitions, setting currentSystem back to the old solar system ID. useFollowEntity would then correct it back to null, creating an oscillation loop.
  - Fixes (4 changes): 
  a. InterstellarTransitionSystem.ts — Added pubsub.publish.ship.players() in both solar→interstellar and interstellar→solar transition paths. This is the core fix that breaks the oscillation cycle.
  b. StarmapCore/index.tsx — Changed SolarSystemWrapper to return null instead of throw new Error("No current system") when currentSystem is null. Prevents an ErrorBoundary crash during a brief Zustand race condition where the child re-renders before the parent swaps it out. 
  c. StarmapCore/index.tsx — Added { placeholderData: keepPreviousData } to the starmapCore.ships.useNetRequest calls in both CanvasWrapper and InterstellarWrapper. Prevents React Suspense from triggering when the query key changes during transitions. 
  d. StarmapCore/data.server.tsx — Changed input?.systemId === undefined to input?.systemId == null in both the ships and torpedoes queries. The client sends systemId: null for interstellar space, but null === undefined is false, so ships and torpedoes were never returned in interstellar view.

  Bug 4: postUpdate loop exits early on Fixed bodies. This wasn't yet causing any observable bugs seemed potentially problematic since collisionEntities aren't guaranteed to be sorted with all fixed bodies last.

  File: app/.server/systems/PhysicsMovementSystem.ts
  - Root cause: In postUpdate, return was used instead of continue when encountering a Fixed rigid body type, causing the entire method to exit and skip processing of remaining entities.
  - Fix: Changed return to continue.

## Related Issue

## How do you know the changes work correctly?

* Tested to verify each bug no longer occurs.

## Screenshots (if appropriate):
