### PR TITLE
feat(satellite): added color changes to the starmap comm satellite meshes to show what "networks" are available

### DIFF
--- a/app/components/Starmap/InterstellarMenuButtons.tsx
+++ b/app/components/Starmap/InterstellarMenuButtons.tsx
@@ -1,12 +1,13 @@
-import * as React from "react";
-import { useParams } from "react-router";
-import { Vector3 } from "three";
-import type { Camera } from "three";
-import { useConfirm } from "@thorium/ui/AlertDialog";
-import Button from "../ui/Button";
 import { q } from "@thorium/context/AppContext";
 import { toast } from "@thorium/context/ToastContext";
+import { useConfirm } from "@thorium/ui/AlertDialog";
 import { lightYearToLightMinute } from "@thorium/utils/unitTypes";
+import type * as React from "react";
+import { ToggleButton } from "react-aria-components";
+import { useParams } from "react-router";
+import type { Camera } from "three";
+import { Vector3 } from "three";
+import Button from "../ui/Button";
 import { useGetStarmapStore } from "./starmapStore";
 
 interface SceneRef {
@@ -25,6 +26,7 @@ export function InterstellarMenuButtons({
 
 	const selectedObjectIds = useStarmapStore((s) => s.selectedObjectIds);
 	const cameraView = useStarmapStore((s) => s.cameraView);
+	const showSatelliteRange = useStarmapStore((s) => s.showSatelliteRange);
 	const confirm = useConfirm();
 	async function deleteObject() {
 		const selectedObjectIds = useStarmapStore.getState().selectedObjectIds;
@@ -105,6 +107,15 @@ export function InterstellarMenuButtons({
 			>
 				Go to {cameraView === "2d" ? "3D" : "2D"}
 			</Button>
+			<ToggleButton
+				isSelected={showSatelliteRange}
+				onChange={(selected) =>
+					useStarmapStore.setState({ showSatelliteRange: selected })
+				}
+				className="btn btn-xs btn-outline btn-info selected:btn-accent"
+			>
+				Satellite Range
+			</ToggleButton>
 		</>
 	);
 }

--- a/app/components/Starmap/SystemMarker/index.tsx
+++ b/app/components/Starmap/SystemMarker/index.tsx
@@ -1,26 +1,29 @@
-import React from "react";
-import { Group, type Mesh, Vector3 } from "three";
-import SystemLabel from "./SystemLabel";
-import SystemCircle, { DraggableSystemCircle } from "./SystemCircle";
-import { useFrame, type ElementProps } from "@react-three/fiber";
-import { useGetStarmapStore } from "../starmapStore";
+import { type ElementProps, useFrame } from "@react-three/fiber";
 import { setCursor } from "@thorium/utils/setCursor";
 import { lightYearToLightMinute } from "@thorium/utils/unitTypes";
-const SystemMarker: React.FC<
-	{
-		systemId: string | number;
-		name: string;
-		position: [number, number, number];
-		draggable?: boolean;
-		commSatelliteRadius: number | null;
-		onPointerDown?: () => void;
-	} & ElementProps<typeof Mesh>
-> = ({
+import React from "react";
+import { Group, type Mesh, Vector3 } from "three";
+import { useGetStarmapStore } from "../starmapStore";
+import SystemCircle from "./SystemCircle";
+import SystemLabel from "./SystemLabel";
+
+interface SystemMarkerProps extends ElementProps<typeof Mesh> {
+	systemId: string | number;
+	name: string;
+	position: [number, number, number];
+	draggable?: boolean;
+	commSatelliteRadius: number | null;
+	commSatelliteColor?: number | null;
+	onPointerDown?: () => void;
+}
+
+const SystemMarker: React.FC<SystemMarkerProps> = ({
 	systemId,
 	name,
 	position,
 	draggable,
 	commSatelliteRadius,
+	commSatelliteColor,
 	...props
 }) => {
 	const group = React.useRef<Group>(new Group());
@@ -28,6 +31,9 @@ const SystemMarker: React.FC<
 
 	const direction = React.useRef(0);
 	const cameraView = useStarmapStore((state) => state.cameraView);
+	const showSatelliteRange = useStarmapStore(
+		(state) => state.showSatelliteRange,
+	);
 
 	useFrame(({ camera }) => {
 		const zoom = group.current?.position
@@ -46,7 +52,7 @@ const SystemMarker: React.FC<
 	if (cameraView === "2d") positionVector.setY(0);
 	return (
 		<>
-			{commSatelliteRadius ? (
+			{showSatelliteRange && commSatelliteRadius ? (
 				<mesh
 					position={positionVector}
 					scale={[
@@ -57,7 +63,7 @@ const SystemMarker: React.FC<
 				>
 					<sphereGeometry args={[lightYearToLightMinute(1), 16, 16]} />
 					<meshBasicMaterial
-						color={0xff8800}
+						color={commSatelliteColor ?? 0xff8800}
 						transparent
 						opacity={0.2}
 						depthTest={false}

--- a/app/components/Starmap/starmapStore.tsx
+++ b/app/components/Starmap/starmapStore.tsx
@@ -1,4 +1,5 @@
 import { useFrame } from "@react-three/fiber";
+import type { Coordinates } from "@thorium/utils/unitTypes";
 import type CameraControls from "camera-controls";
 import {
 	createContext,
@@ -7,7 +8,6 @@ import {
 	useContext,
 	useState,
 } from "react";
-import type { Coordinates } from "@thorium/utils/unitTypes";
 import { type Plane, Vector3 } from "three";
 import { create } from "zustand";
 
@@ -41,6 +41,7 @@ interface StarmapStore {
 	setCameraFocus: (position: Coordinates<number>) => void;
 	planetsHidden: boolean;
 	sensorsHidden: boolean;
+	showSatelliteRange: boolean;
 	clickAction?: { label: string; action: (object: number | null) => void };
 }
 
@@ -98,6 +99,7 @@ const createStarmapStore = () =>
 		},
 		planetsHidden: false,
 		sensorsHidden: true,
+		showSatelliteRange: true,
 	}));
 
 const useStarmapStore = createStarmapStore();

--- a/app/routes/config/starmap/index.tsx
+++ b/app/routes/config/starmap/index.tsx
@@ -1,7 +1,9 @@
 import { InterstellarMap } from "@thorium/components/Starmap/InterstellarMap";
-import { useGetStarmapStore } from "@thorium/components/Starmap/starmapStore";
 import SystemMarker from "@thorium/components/Starmap/SystemMarker";
+import { useGetStarmapStore } from "@thorium/components/Starmap/starmapStore";
 import { q } from "@thorium/context/AppContext";
+import { computeNetworkColors } from "@thorium/routes/config/starmap/starmapUtils";
+import { useMemo } from "react";
 import { href, useNavigate, useParams } from "react-router";
 
 export default function InterstellarWrapper({
@@ -21,6 +23,7 @@ export default function InterstellarWrapper({
 	const useStarmapStore = useGetStarmapStore();
 
 	const [stars] = q.plugin.starmap.all.useNetRequest({ pluginId });
+	const networkColors = useMemo(() => computeNetworkColors(stars), [stars]);
 	return (
 		<InterstellarMap>
 			{stars.map((star) => (
@@ -30,6 +33,7 @@ export default function InterstellarWrapper({
 					position={Object.values(star.position) as [number, number, number]}
 					name={star.name}
 					commSatelliteRadius={star.commSatelliteRadius || null}
+					commSatelliteColor={networkColors.get(star.name) ?? null}
 					draggable={draggable}
 					onPointerDown={() => {
 						useStarmapStore.setState({ selectedObjectIds: [star.name] });

--- a/app/routes/config/starmap/starmapUtils.ts
+++ b/app/routes/config/starmap/starmapUtils.ts
@@ -1,0 +1,84 @@
+import { lightYearToLightMinute } from "@thorium/utils/unitTypes";
+
+// Colors chosen for maximum hue separation (~30-40° apart) so they remain
+// distinguishable at the sphere's 0.2 opacity. Hue annotations are approximate.
+const NETWORK_COLOR_PALETTE = [
+	0x00b5a3, // teal      ~175°
+	0x00cc44, // green     ~140°
+	0xff8c00, // orange     ~33°
+	0x9b59ff, // purple    ~265°
+	0x00cfff, // cyan      ~195°
+	0xff44ff, // magenta   ~300°
+	0x4488ff, // blue      ~220°
+	0xff4466, // rose      ~350°
+	0xffdd00, // amber      ~52°
+];
+
+type StarEntry = {
+	name: string;
+	position: { x: number; y: number; z: number };
+	commSatelliteRadius?: number | null;
+};
+
+export function computeNetworkColors(stars: StarEntry[]): Map<string, number> {
+	const commStars = stars.filter((s) => s.commSatelliteRadius);
+	if (commStars.length === 0) return new Map();
+
+	// Union-Find with path compression and union by rank
+	const parent = commStars.map((_, i) => i);
+	const rank = new Array<number>(commStars.length).fill(0);
+
+	function find(i: number): number {
+		if (parent[i] !== i) parent[i] = find(parent[i]);
+		return parent[i];
+	}
+
+	function union(i: number, j: number) {
+		const pi = find(i);
+		const pj = find(j);
+		if (pi === pj) return;
+		if (rank[pi] < rank[pj]) parent[pi] = pj;
+		else if (rank[pi] > rank[pj]) parent[pj] = pi;
+		else {
+			parent[pj] = pi;
+			rank[pi]++;
+		}
+	}
+
+	// Build edges: two satellites are connected if distance ≤ either radius
+	const radiiLM = commStars.map((s) =>
+		lightYearToLightMinute(s.commSatelliteRadius!),
+	);
+	for (let i = 0; i < commStars.length; i++) {
+		for (let j = i + 1; j < commStars.length; j++) {
+			const dist = Math.hypot(
+				commStars[i].position.x - commStars[j].position.x,
+				commStars[i].position.y - commStars[j].position.y,
+				commStars[i].position.z - commStars[j].position.z,
+			);
+			if (dist <= radiiLM[i] || dist <= radiiLM[j]) {
+				union(i, j);
+			}
+		}
+	}
+
+	// Assign colors in list order so the first satellite in each component
+	// anchors the color for that network
+	const componentColors = new Map<number, number>();
+	let nextColorIndex = 0;
+	const result = new Map<string, number>();
+
+	for (let i = 0; i < commStars.length; i++) {
+		const root = find(i);
+		if (!componentColors.has(root)) {
+			componentColors.set(
+				root,
+				NETWORK_COLOR_PALETTE[nextColorIndex % NETWORK_COLOR_PALETTE.length],
+			);
+			nextColorIndex++;
+		}
+		result.set(commStars[i].name, componentColors.get(root)!);
+	}
+
+	return result;
+}


### PR DESCRIPTION

## Description of Changes
added color changes to the starmap comm satellite meshes to show what "networks" are in range.

## How do you know the changes work correctly?
Ran the starmap editor

## Screenshots (if appropriate):
<img width="836" height="808" alt="image" src="https://github.com/user-attachments/assets/03e9d193-86bc-48ed-8aad-92b03ca95f75" />
